### PR TITLE
Changed "1u" to "1.00u" to match the rest of the footprints

### DIFF
--- a/Button_Switch_Keyboard.pretty/SW_Cherry_MX1A_1.00u_PCB.kicad_mod
+++ b/Button_Switch_Keyboard.pretty/SW_Cherry_MX1A_1.00u_PCB.kicad_mod
@@ -1,6 +1,6 @@
 (module SW_Cherry_MX1A_1.00u_PCB (layer F.Cu) (tedit 5A02FE24)
-  (descr "Cherry MX keyswitch, MX1A, 1u, PCB mount, http://cherryamericas.com/wp-content/uploads/2014/12/mx_cat.pdf")
-  (tags "cherry mx keyswitch MX1A 1u PCB")
+  (descr "Cherry MX keyswitch, MX1A, 1.00u, PCB mount, http://cherryamericas.com/wp-content/uploads/2014/12/mx_cat.pdf")
+  (tags "cherry mx keyswitch MX1A 1.00u PCB")
   (fp_text reference REF** (at -2.54 -2.794) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))
   )

--- a/Button_Switch_Keyboard.pretty/SW_Cherry_MX1A_1.00u_Plate.kicad_mod
+++ b/Button_Switch_Keyboard.pretty/SW_Cherry_MX1A_1.00u_Plate.kicad_mod
@@ -1,6 +1,6 @@
 (module SW_Cherry_MX1A_1.00u_Plate (layer F.Cu) (tedit 5A02FE24)
-  (descr "Cherry MX keyswitch, MX1A, 1u, plate mount, http://cherryamericas.com/wp-content/uploads/2014/12/mx_cat.pdf")
-  (tags "cherry mx keyswitch MX1A 1u plate")
+  (descr "Cherry MX keyswitch, MX1A, 1.00u, plate mount, http://cherryamericas.com/wp-content/uploads/2014/12/mx_cat.pdf")
+  (tags "cherry mx keyswitch MX1A 1.00u plate")
   (fp_text reference REF** (at -2.54 -2.794) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))
   )


### PR DESCRIPTION
Discovered from looking at kicad.github.io that I'd forgotten to add the trailing decimal point and zeroes to the 1u footprints in their description and tags. Now they all match :)