### PR TITLE
Fix fp-lib-table entry for TerminalBlock_Philmore

### DIFF
--- a/fp-lib-table
+++ b/fp-lib-table
@@ -64,7 +64,7 @@
   (lib (name Symbol)(type KiCad)(uri ${KISYSMOD}/Symbol.pretty)(options "")(descr "PCB symbols"))
   (lib (name TerminalBlock_4Ucon)(type KiCad)(uri ${KISYSMOD}/TerminalBlock_4Ucon.pretty)(options "")(descr "4UCON terminal blocks"))
   (lib (name TerminalBlock_MetzConnect)(type KiCad)(uri ${KISYSMOD}/TerminalBlock_MetzConnect.pretty)(options "")(descr "Metz Connect terminal blocks"))
-  (lib (name TerminalBlock_Philmore)(type KiCad)(uri ${KISYSMOD}/TerminalBlock_Phoenix.pretty)(options "")(descr "Philmore terminal blocks"))
+  (lib (name TerminalBlock_Philmore)(type KiCad)(uri ${KISYSMOD}/TerminalBlock_Philmore.pretty)(options "")(descr "Philmore terminal blocks"))
   (lib (name TerminalBlock_Phoenix)(type KiCad)(uri ${KISYSMOD}/TerminalBlock_Phoenix.pretty)(options "")(descr "RND terminal blocks"))
   (lib (name TerminalBlock_RND)(type KiCad)(uri ${KISYSMOD}/TerminalBlock_RND.pretty)(options "")(descr "Phoenix Contact terminal blocks"))
   (lib (name TerminalBlock_WAGO)(type KiCad)(uri ${KISYSMOD}/TerminalBlock_WAGO.pretty)(options "")(descr "WAGO terminal blocks"))


### PR DESCRIPTION
This should fix the current travis errors about the fp-lib-table