### PR TITLE
Add dash between WSON and number of pins

### DIFF
--- a/Package_SON.pretty/WSON-6_1.5x1.5mm_P0.5mm.kicad_mod
+++ b/Package_SON.pretty/WSON-6_1.5x1.5mm_P0.5mm.kicad_mod
@@ -1,4 +1,4 @@
-(module WSON6_1.5x1.5mm_P0.5mm (layer F.Cu) (tedit 5A02F1D8)
+(module WSON-6_1.5x1.5mm_P0.5mm (layer F.Cu) (tedit 5A02F1D8)
   (descr "WSON6, http://www.ti.com/lit/ds/symlink/tlv702.pdf")
   (tags WSON6_1.5x1.5mm_P0.5mm)
   (attr smd)
@@ -28,7 +28,7 @@
   (pad 4 smd rect (at 0.575 0.5 270) (size 0.28 0.75) (layers F.Cu F.Paste F.Mask))
   (pad 5 smd rect (at 0.575 0 270) (size 0.28 0.75) (layers F.Cu F.Paste F.Mask))
   (pad 6 smd rect (at 0.575 -0.5 270) (size 0.28 0.75) (layers F.Cu F.Paste F.Mask))
-  (model ${KISYS3DMOD}/Package_SON.3dshapes/WSON6_1.5x1.5mm_P0.5mm.wrl
+  (model ${KISYS3DMOD}/Package_SON.3dshapes/WSON-6_1.5x1.5mm_P0.5mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/Package_SON.pretty/WSON-8_4x4mm_P0.8mm.kicad_mod
+++ b/Package_SON.pretty/WSON-8_4x4mm_P0.8mm.kicad_mod
@@ -1,4 +1,4 @@
-(module WSON8_4x4mm_P0.8mm (layer F.Cu) (tedit 5A02F1D8)
+(module WSON-8_4x4mm_P0.8mm (layer F.Cu) (tedit 5A02F1D8)
   (descr http://www.ti.com/lit/ml/mpds406/mpds406.pdf)
   (tags WSON8_4x4mm_P0.8mm)
   (attr smd)
@@ -31,7 +31,7 @@
   (pad 7 smd rect (at 1.9 -0.4 270) (size 0.3 0.6) (layers F.Cu F.Paste F.Mask))
   (pad 8 smd rect (at 1.9 -1.2 270) (size 0.3 0.6) (layers F.Cu F.Paste F.Mask))
   (pad 9 smd rect (at 0 0) (size 2.6 3) (layers F.Cu F.Paste F.Mask))
-  (model ${KISYS3DMOD}/Package_SON.3dshapes/WSON8_4x4mm_P0.8mm.wrl
+  (model ${KISYS3DMOD}/Package_SON.3dshapes/WSON-8_4x4mm_P0.8mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))


### PR DESCRIPTION
Looking at https://github.com/KiCad/kicad-symbols/pull/109 i noticed that two of the WSON packages had a missing dash between the package name and number of pins. This PR does fix that.
