### PR TITLE
Fix metric code for standard 1020 resistor

### DIFF
--- a/Resistor_SMD.pretty/R_1020_2550Metric.kicad_mod
+++ b/Resistor_SMD.pretty/R_1020_2550Metric.kicad_mod
@@ -1,11 +1,11 @@
-(module R_1020_1632Metric (layer F.Cu) (tedit 59FE48B8)
+(module R_1020_2550Metric (layer F.Cu) (tedit 59FE48B8)
   (descr "Resistor SMD 1020 (1632 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: https://www.vishay.com/docs/20019/rcwe.pdf), generated with kicad-footprint-generator")
   (tags resistor)
   (attr smd)
   (fp_text reference REF** (at 0 -3.75) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (fp_text value R_1020_1632Metric (at 0 3.75) (layer F.Fab)
+  (fp_text value R_1020_2550Metric (at 0 3.75) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
   (fp_line (start -1.25 2.5) (end -1.25 -2.5) (layer F.Fab) (width 0.1))
@@ -23,7 +23,7 @@
   (fp_text user %R (at 0 0 90) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Resistor_SMD.3dshapes/R_1020_1632Metric.wrl
+  (model ${KISYS3DMOD}/Resistor_SMD.3dshapes/R_1020_2550Metric.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))


### PR DESCRIPTION
This should finally fix https://github.com/KiCad/kicad-footprints/issues/174