### PR TITLE
Update CMakeLists.txt to install only .pretty

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,9 +42,11 @@ add_custom_target( uninstall
 #================================================
 # Installed files.
 #================================================
+# select pretty directories
+file (GLOB PRETTY_DIRS "*.pretty")
 
 # Install the contents of all of the .pretty folders in to the modules path.
-install( DIRECTORY ./
+install( DIRECTORY ${PRETTY_DIRS}
     DESTINATION ${KICAD_MODULES}
     COMPONENT resources
     FILES_MATCHING PATTERN "*.kicad_mod"


### PR DESCRIPTION
Modify installation to install only *.pretty directories.
All other directories (for example CMakeModules) should not be installed.

------------

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the footprint(s) you are contributing
- [ ] An example screenshot image is very helpful 
- [ ] If there are matching symbol or 3D model PRs, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
