### PR TITLE
Add TerminalBlock_Dinkle to fp-lib-table

### DIFF
--- a/fp-lib-table
+++ b/fp-lib-table
@@ -91,6 +91,7 @@
   (lib (name Symbol)(type KiCad)(uri ${KISYSMOD}/Symbol.pretty)(options "")(descr "PCB symbols"))
   (lib (name TerminalBlock)(type KiCad)(uri ${KISYSMOD}/TerminalBlock.pretty)(options "")(descr "Footprints for terminal blocks that do not have their own manufacturer specific library."))
   (lib (name TerminalBlock_4Ucon)(type KiCad)(uri ${KISYSMOD}/TerminalBlock_4Ucon.pretty)(options "")(descr "4UCON terminal blocks"))
+  (lib (name TerminalBlock_Dinkle)(type KiCad)(uri ${KISYSMOD}/TerminalBlock_Dinkle.pretty)(options "")(descr "Dinkle terminal blocks"))
   (lib (name TerminalBlock_MetzConnect)(type KiCad)(uri ${KISYSMOD}/TerminalBlock_MetzConnect.pretty)(options "")(descr "Metz Connect terminal blocks"))
   (lib (name TerminalBlock_Philmore)(type KiCad)(uri ${KISYSMOD}/TerminalBlock_Philmore.pretty)(options "")(descr "Philmore terminal blocks"))
   (lib (name TerminalBlock_Phoenix)(type KiCad)(uri ${KISYSMOD}/TerminalBlock_Phoenix.pretty)(options "")(descr "RND terminal blocks"))


### PR DESCRIPTION
It seems that TerminalBlock_Dinkle was missing from fp-lib-table, giving travis script errors

------------

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the footprint(s) you are contributing
- [ ] An example screenshot image is very helpful 
- [ ] If there are matching symbol or 3D model PRs, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
