### PR TITLE
Use the -1SH footprint name syntax for shielded connectors

### DIFF
--- a/Connector_Samtec.pretty/Samtec_LSHM-105-xx.x-x-DV-S_2x05-1SH_P0.50mm_Vertical.kicad_mod
+++ b/Connector_Samtec.pretty/Samtec_LSHM-105-xx.x-x-DV-S_2x05-1SH_P0.50mm_Vertical.kicad_mod
@@ -1,11 +1,11 @@
-(module Samtec_LSHM-105-xx.x-x-DV-S_2x05_P0.50mm_Vertical_Shielded (layer F.Cu) (tedit 5A273B50)
+(module Samtec_LSHM-105-xx.x-x-DV-S_2x05-1SH_P0.50mm_Vertical (layer F.Cu) (tedit 5A7E26C4)
   (descr "Molex LSHM 0.50 mm Razor Beam High-Speed Hermaphroditic Terminal/Socket Strip, LSHM-105-xx.x-x-DV-S, 5 Pins per row (http://suddendocs.samtec.com/prints/lshm-1xx-xx.x-x-dv-a-x-x-tr-footprint.pdf), generated with kicad-footprint-generator")
   (tags "connector Samtec  side entry")
   (attr smd)
   (fp_text reference REF** (at 0 -3.8) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (fp_text value Samtec_LSHM-105-xx.x-x-DV-S_2x05_P0.50mm_Vertical_Shielded (at 0 3.8) (layer F.Fab)
+  (fp_text value Samtec_LSHM-105-xx.x-x-DV-S_2x05-1SH_P0.50mm_Vertical (at 0 3.8) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
   (fp_line (start 0 -2.49) (end -4.075 -2.49) (layer F.Fab) (width 0.1))
@@ -56,7 +56,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Connector_Samtec.3dshapes/Samtec_LSHM-105-xx.x-x-DV-S_2x05_P0.50mm_Vertical_Shielded.wrl
+  (model ${KISYS3DMOD}/Connector_Samtec.3dshapes/Samtec_LSHM-105-xx.x-x-DV-S_2x05-1SH_P0.50mm_Vertical.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/Connector_Samtec.pretty/Samtec_LSHM-110-xx.x-x-DV-S_2x10-1SH_P0.50mm_Vertical.kicad_mod
+++ b/Connector_Samtec.pretty/Samtec_LSHM-110-xx.x-x-DV-S_2x10-1SH_P0.50mm_Vertical.kicad_mod
@@ -1,11 +1,11 @@
-(module Samtec_LSHM-110-xx.x-x-DV-S_2x10_P0.50mm_Vertical_Shielded (layer F.Cu) (tedit 5A273B50)
+(module Samtec_LSHM-110-xx.x-x-DV-S_2x10-1SH_P0.50mm_Vertical (layer F.Cu) (tedit 5A7E26C4)
   (descr "Molex LSHM 0.50 mm Razor Beam High-Speed Hermaphroditic Terminal/Socket Strip, LSHM-110-xx.x-x-DV-S, 10 Pins per row (http://suddendocs.samtec.com/prints/lshm-1xx-xx.x-x-dv-a-x-x-tr-footprint.pdf), generated with kicad-footprint-generator")
   (tags "connector Samtec  side entry")
   (attr smd)
   (fp_text reference REF** (at 0 -3.8) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (fp_text value Samtec_LSHM-110-xx.x-x-DV-S_2x10_P0.50mm_Vertical_Shielded (at 0 3.8) (layer F.Fab)
+  (fp_text value Samtec_LSHM-110-xx.x-x-DV-S_2x10-1SH_P0.50mm_Vertical (at 0 3.8) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
   (fp_line (start 0 -2.49) (end -5.325 -2.49) (layer F.Fab) (width 0.1))
@@ -66,7 +66,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Connector_Samtec.3dshapes/Samtec_LSHM-110-xx.x-x-DV-S_2x10_P0.50mm_Vertical_Shielded.wrl
+  (model ${KISYS3DMOD}/Connector_Samtec.3dshapes/Samtec_LSHM-110-xx.x-x-DV-S_2x10-1SH_P0.50mm_Vertical.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/Connector_Samtec.pretty/Samtec_LSHM-120-xx.x-x-DV-S_2x20-1SH_P0.50mm_Vertical.kicad_mod
+++ b/Connector_Samtec.pretty/Samtec_LSHM-120-xx.x-x-DV-S_2x20-1SH_P0.50mm_Vertical.kicad_mod
@@ -1,11 +1,11 @@
-(module Samtec_LSHM-120-xx.x-x-DV-S_2x20_P0.50mm_Vertical_Shielded (layer F.Cu) (tedit 5A273B50)
+(module Samtec_LSHM-120-xx.x-x-DV-S_2x20-1SH_P0.50mm_Vertical (layer F.Cu) (tedit 5A7E26C4)
   (descr "Molex LSHM 0.50 mm Razor Beam High-Speed Hermaphroditic Terminal/Socket Strip, LSHM-120-xx.x-x-DV-S, 20 Pins per row (http://suddendocs.samtec.com/prints/lshm-1xx-xx.x-x-dv-a-x-x-tr-footprint.pdf), generated with kicad-footprint-generator")
   (tags "connector Samtec  side entry")
   (attr smd)
   (fp_text reference REF** (at 0 -3.8) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (fp_text value Samtec_LSHM-120-xx.x-x-DV-S_2x20_P0.50mm_Vertical_Shielded (at 0 3.8) (layer F.Fab)
+  (fp_text value Samtec_LSHM-120-xx.x-x-DV-S_2x20-1SH_P0.50mm_Vertical (at 0 3.8) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
   (fp_line (start 0 -2.49) (end -7.825 -2.49) (layer F.Fab) (width 0.1))
@@ -86,7 +86,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Connector_Samtec.3dshapes/Samtec_LSHM-120-xx.x-x-DV-S_2x20_P0.50mm_Vertical_Shielded.wrl
+  (model ${KISYS3DMOD}/Connector_Samtec.3dshapes/Samtec_LSHM-120-xx.x-x-DV-S_2x20-1SH_P0.50mm_Vertical.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/Connector_Samtec.pretty/Samtec_LSHM-130-xx.x-x-DV-S_2x30-1SH_P0.50mm_Vertical.kicad_mod
+++ b/Connector_Samtec.pretty/Samtec_LSHM-130-xx.x-x-DV-S_2x30-1SH_P0.50mm_Vertical.kicad_mod
@@ -1,11 +1,11 @@
-(module Samtec_LSHM-130-xx.x-x-DV-S_2x30_P0.50mm_Vertical_Shielded (layer F.Cu) (tedit 5A273B50)
+(module Samtec_LSHM-130-xx.x-x-DV-S_2x30-1SH_P0.50mm_Vertical (layer F.Cu) (tedit 5A7E26C4)
   (descr "Molex LSHM 0.50 mm Razor Beam High-Speed Hermaphroditic Terminal/Socket Strip, LSHM-130-xx.x-x-DV-S, 30 Pins per row (http://suddendocs.samtec.com/prints/lshm-1xx-xx.x-x-dv-a-x-x-tr-footprint.pdf), generated with kicad-footprint-generator")
   (tags "connector Samtec  side entry")
   (attr smd)
   (fp_text reference REF** (at 0 -3.8) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (fp_text value Samtec_LSHM-130-xx.x-x-DV-S_2x30_P0.50mm_Vertical_Shielded (at 0 3.8) (layer F.Fab)
+  (fp_text value Samtec_LSHM-130-xx.x-x-DV-S_2x30-1SH_P0.50mm_Vertical (at 0 3.8) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
   (fp_line (start 0 -2.49) (end -10.325 -2.49) (layer F.Fab) (width 0.1))
@@ -106,7 +106,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Connector_Samtec.3dshapes/Samtec_LSHM-130-xx.x-x-DV-S_2x30_P0.50mm_Vertical_Shielded.wrl
+  (model ${KISYS3DMOD}/Connector_Samtec.3dshapes/Samtec_LSHM-130-xx.x-x-DV-S_2x30-1SH_P0.50mm_Vertical.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/Connector_Samtec.pretty/Samtec_LSHM-140-xx.x-x-DV-S_2x40-1SH_P0.50mm_Vertical.kicad_mod
+++ b/Connector_Samtec.pretty/Samtec_LSHM-140-xx.x-x-DV-S_2x40-1SH_P0.50mm_Vertical.kicad_mod
@@ -1,11 +1,11 @@
-(module Samtec_LSHM-140-xx.x-x-DV-S_2x40_P0.50mm_Vertical_Shielded (layer F.Cu) (tedit 5A273B50)
+(module Samtec_LSHM-140-xx.x-x-DV-S_2x40-1SH_P0.50mm_Vertical (layer F.Cu) (tedit 5A7E26C4)
   (descr "Molex LSHM 0.50 mm Razor Beam High-Speed Hermaphroditic Terminal/Socket Strip, LSHM-140-xx.x-x-DV-S, 40 Pins per row (http://suddendocs.samtec.com/prints/lshm-1xx-xx.x-x-dv-a-x-x-tr-footprint.pdf), generated with kicad-footprint-generator")
   (tags "connector Samtec  side entry")
   (attr smd)
   (fp_text reference REF** (at 0 -3.8) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (fp_text value Samtec_LSHM-140-xx.x-x-DV-S_2x40_P0.50mm_Vertical_Shielded (at 0 3.8) (layer F.Fab)
+  (fp_text value Samtec_LSHM-140-xx.x-x-DV-S_2x40-1SH_P0.50mm_Vertical (at 0 3.8) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
   (fp_line (start 0 -2.49) (end -12.825 -2.49) (layer F.Fab) (width 0.1))
@@ -126,7 +126,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Connector_Samtec.3dshapes/Samtec_LSHM-140-xx.x-x-DV-S_2x40_P0.50mm_Vertical_Shielded.wrl
+  (model ${KISYS3DMOD}/Connector_Samtec.3dshapes/Samtec_LSHM-140-xx.x-x-DV-S_2x40-1SH_P0.50mm_Vertical.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/Connector_Samtec.pretty/Samtec_LSHM-150-xx.x-x-DV-S_2x50-1SH_P0.50mm_Vertical.kicad_mod
+++ b/Connector_Samtec.pretty/Samtec_LSHM-150-xx.x-x-DV-S_2x50-1SH_P0.50mm_Vertical.kicad_mod
@@ -1,11 +1,11 @@
-(module Samtec_LSHM-150-xx.x-x-DV-S_2x50_P0.50mm_Vertical_Shielded (layer F.Cu) (tedit 5A273B50)
+(module Samtec_LSHM-150-xx.x-x-DV-S_2x50-1SH_P0.50mm_Vertical (layer F.Cu) (tedit 5A7E26C4)
   (descr "Molex LSHM 0.50 mm Razor Beam High-Speed Hermaphroditic Terminal/Socket Strip, LSHM-150-xx.x-x-DV-S, 50 Pins per row (http://suddendocs.samtec.com/prints/lshm-1xx-xx.x-x-dv-a-x-x-tr-footprint.pdf), generated with kicad-footprint-generator")
   (tags "connector Samtec  side entry")
   (attr smd)
   (fp_text reference REF** (at 0 -3.8) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (fp_text value Samtec_LSHM-150-xx.x-x-DV-S_2x50_P0.50mm_Vertical_Shielded (at 0 3.8) (layer F.Fab)
+  (fp_text value Samtec_LSHM-150-xx.x-x-DV-S_2x50-1SH_P0.50mm_Vertical (at 0 3.8) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
   (fp_line (start 0 -2.49) (end -15.325 -2.49) (layer F.Fab) (width 0.1))
@@ -146,7 +146,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Connector_Samtec.3dshapes/Samtec_LSHM-150-xx.x-x-DV-S_2x50_P0.50mm_Vertical_Shielded.wrl
+  (model ${KISYS3DMOD}/Connector_Samtec.3dshapes/Samtec_LSHM-150-xx.x-x-DV-S_2x50-1SH_P0.50mm_Vertical.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))


### PR DESCRIPTION
This is the sister PR for https://github.com/KiCad/kicad-symbols/pull/293

Script PR https://github.com/pointhi/kicad-footprint-generator/pull/111