### PR TITLE
Remove 3D models from SMD HC49 crystals (inexistent)

### DIFF
--- a/Crystal.pretty/Crystal_SMD_HC49-SD.kicad_mod
+++ b/Crystal.pretty/Crystal_SMD_HC49-SD.kicad_mod
@@ -28,9 +28,4 @@
   (fp_arc (start 3.015 0) (end 3.015 -2.115) (angle 180) (layer F.Fab) (width 0.1))
   (pad 1 smd rect (at -4.25 0) (size 4.5 2) (layers F.Cu F.Paste F.Mask))
   (pad 2 smd rect (at 4.25 0) (size 4.5 2) (layers F.Cu F.Paste F.Mask))
-  (model ${KISYS3DMOD}/Crystal.3dshapes/Crystal_SMD_HC49-SD.wrl
-    (at (xyz 0 0 0))
-    (scale (xyz 1 1 1))
-    (rotate (xyz 0 0 0))
-  )
 )

--- a/Crystal.pretty/Crystal_SMD_HC49-SD_HandSoldering.kicad_mod
+++ b/Crystal.pretty/Crystal_SMD_HC49-SD_HandSoldering.kicad_mod
@@ -28,9 +28,4 @@
   (fp_arc (start 3.015 0) (end 3.015 -2.115) (angle 180) (layer F.Fab) (width 0.1))
   (pad 1 smd rect (at -5.9375 0) (size 7.875 2) (layers F.Cu F.Paste F.Mask))
   (pad 2 smd rect (at 5.9375 0) (size 7.875 2) (layers F.Cu F.Paste F.Mask))
-  (model ${KISYS3DMOD}/Crystal.3dshapes/Crystal_SMD_HC49-SD_HandSoldering.wrl
-    (at (xyz 0 0 0))
-    (scale (xyz 1 1 1))
-    (rotate (xyz 0 0 0))
-  )
 )


### PR DESCRIPTION
Remove inexistent models.
Not found in https://github.com/KiCad/kicad-packages3D/tree/master/Crystal.3dshapes