### PR TITLE
Use same model for HandSoldering version of SMD HC49 crystal.

### DIFF
--- a/Crystal.pretty/Crystal_SMD_HC49-SD_HandSoldering.kicad_mod
+++ b/Crystal.pretty/Crystal_SMD_HC49-SD_HandSoldering.kicad_mod
@@ -28,7 +28,7 @@
   (fp_arc (start 3.015 0) (end 3.015 -2.115) (angle 180) (layer F.Fab) (width 0.1))
   (pad 1 smd rect (at -5.9375 0) (size 7.875 2) (layers F.Cu F.Paste F.Mask))
   (pad 2 smd rect (at 5.9375 0) (size 7.875 2) (layers F.Cu F.Paste F.Mask))
-  (model ${KISYS3DMOD}/Crystal.3dshapes/Crystal_SMD_HC49-SD_HandSoldering.wrl
+  (model ${KISYS3DMOD}/Crystal.3dshapes/Crystal_SMD_HC49-SD.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))


### PR DESCRIPTION
HandSoldering or not, the 3D should be the same.
Note: that model is missing at the moment.