### PR TITLE
Use circular pads for varistor footprints

### DIFF
--- a/Varistor.pretty/RV_Disc_D12mm_W3.9mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D12mm_W3.9mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2.25 -1.25) (end 9.75 -1.25) (layer F.Fab) (width 0.1))
   (fp_line (start 9.75 -1.25) (end 9.75 2.65) (layer F.Fab) (width 0.1))
   (fp_line (start -2.25 -1.25) (end -2.25 2.65) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 1.4) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D12mm_W3.9mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D12mm_W4.2mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D12mm_W4.2mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2.25 -1.28333) (end 9.75 -1.28333) (layer F.Fab) (width 0.1))
   (fp_line (start 9.75 -1.28333) (end 9.75 2.91667) (layer F.Fab) (width 0.1))
   (fp_line (start -2.25 -1.28333) (end -2.25 2.91667) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 1.63333) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D12mm_W4.2mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D12mm_W4.3mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D12mm_W4.3mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2.25 -1.2) (end 9.75 -1.2) (layer F.Fab) (width 0.1))
   (fp_line (start 9.75 -1.2) (end 9.75 3.1) (layer F.Fab) (width 0.1))
   (fp_line (start -2.25 -1.2) (end -2.25 3.1) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 1.9) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D12mm_W4.3mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D12mm_W4.4mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D12mm_W4.4mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2.25 -1.3125) (end 9.75 -1.3125) (layer F.Fab) (width 0.1))
   (fp_line (start 9.75 -1.3125) (end 9.75 3.0875) (layer F.Fab) (width 0.1))
   (fp_line (start -2.25 -1.3125) (end -2.25 3.0875) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 1.775) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D12mm_W4.4mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D12mm_W4.5mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D12mm_W4.5mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2.25 -1.35) (end 9.75 -1.35) (layer F.Fab) (width 0.1))
   (fp_line (start 9.75 -1.35) (end 9.75 3.15) (layer F.Fab) (width 0.1))
   (fp_line (start -2.25 -1.35) (end -2.25 3.15) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 1.8) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D12mm_W4.5mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D12mm_W4.6mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D12mm_W4.6mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2.25 -1.2) (end 9.75 -1.2) (layer F.Fab) (width 0.1))
   (fp_line (start 9.75 -1.2) (end 9.75 3.4) (layer F.Fab) (width 0.1))
   (fp_line (start -2.25 -1.2) (end -2.25 3.4) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 2.2) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D12mm_W4.6mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D12mm_W4.7mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D12mm_W4.7mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2.25 -1.35) (end 9.75 -1.35) (layer F.Fab) (width 0.1))
   (fp_line (start 9.75 -1.35) (end 9.75 3.35) (layer F.Fab) (width 0.1))
   (fp_line (start -2.25 -1.35) (end -2.25 3.35) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 2) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D12mm_W4.7mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D12mm_W4.8mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D12mm_W4.8mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2.25 -1.375) (end 9.75 -1.375) (layer F.Fab) (width 0.1))
   (fp_line (start 9.75 -1.375) (end 9.75 3.425) (layer F.Fab) (width 0.1))
   (fp_line (start -2.25 -1.375) (end -2.25 3.425) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 2.05) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D12mm_W4.8mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D12mm_W4mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D12mm_W4mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2.25 -1.275) (end 9.75 -1.275) (layer F.Fab) (width 0.1))
   (fp_line (start 9.75 -1.275) (end 9.75 2.725) (layer F.Fab) (width 0.1))
   (fp_line (start -2.25 -1.275) (end -2.25 2.725) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 1.45) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D12mm_W4mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D12mm_W5.1mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D12mm_W5.1mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2.25 -1.4) (end 9.75 -1.4) (layer F.Fab) (width 0.1))
   (fp_line (start 9.75 -1.4) (end 9.75 3.7) (layer F.Fab) (width 0.1))
   (fp_line (start -2.25 -1.4) (end -2.25 3.7) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 2.3) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D12mm_W5.1mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D12mm_W5.4mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D12mm_W5.4mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2.25 -1.5) (end 9.75 -1.5) (layer F.Fab) (width 0.1))
   (fp_line (start 9.75 -1.5) (end 9.75 3.9) (layer F.Fab) (width 0.1))
   (fp_line (start -2.25 -1.5) (end -2.25 3.9) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 2.4) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D12mm_W5.4mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D12mm_W5.8mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D12mm_W5.8mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2.25 -1.55) (end 9.75 -1.55) (layer F.Fab) (width 0.1))
   (fp_line (start 9.75 -1.55) (end 9.75 4.25) (layer F.Fab) (width 0.1))
   (fp_line (start -2.25 -1.55) (end -2.25 4.25) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 2.7) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D12mm_W5.8mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D12mm_W5mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D12mm_W5mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2.25 -1.4) (end 9.75 -1.4) (layer F.Fab) (width 0.1))
   (fp_line (start 9.75 -1.4) (end 9.75 3.6) (layer F.Fab) (width 0.1))
   (fp_line (start -2.25 -1.4) (end -2.25 3.6) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 2.2) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D12mm_W5mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D12mm_W6.1mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D12mm_W6.1mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2.25 -1.6) (end 9.75 -1.6) (layer F.Fab) (width 0.1))
   (fp_line (start 9.75 -1.6) (end 9.75 4.5) (layer F.Fab) (width 0.1))
   (fp_line (start -2.25 -1.6) (end -2.25 4.5) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 2.9) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D12mm_W6.1mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D12mm_W6.2mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D12mm_W6.2mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2.25 -1.6) (end 9.75 -1.6) (layer F.Fab) (width 0.1))
   (fp_line (start 9.75 -1.6) (end 9.75 4.6) (layer F.Fab) (width 0.1))
   (fp_line (start -2.25 -1.6) (end -2.25 4.6) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 3) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D12mm_W6.2mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D12mm_W6.3mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D12mm_W6.3mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2.25 -1.6) (end 9.75 -1.6) (layer F.Fab) (width 0.1))
   (fp_line (start 9.75 -1.6) (end 9.75 4.7) (layer F.Fab) (width 0.1))
   (fp_line (start -2.25 -1.6) (end -2.25 4.7) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 3.1) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D12mm_W6.3mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D12mm_W6.7mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D12mm_W6.7mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2.25 -1.65) (end 9.75 -1.65) (layer F.Fab) (width 0.1))
   (fp_line (start 9.75 -1.65) (end 9.75 5.05) (layer F.Fab) (width 0.1))
   (fp_line (start -2.25 -1.65) (end -2.25 5.05) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 3.4) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D12mm_W6.7mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D12mm_W7.1mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D12mm_W7.1mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2.25 -1.7) (end 9.75 -1.7) (layer F.Fab) (width 0.1))
   (fp_line (start 9.75 -1.7) (end 9.75 5.4) (layer F.Fab) (width 0.1))
   (fp_line (start -2.25 -1.7) (end -2.25 5.4) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 3.7) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D12mm_W7.1mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D12mm_W7.5mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D12mm_W7.5mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2.25 -1.75) (end 9.75 -1.75) (layer F.Fab) (width 0.1))
   (fp_line (start 9.75 -1.75) (end 9.75 5.75) (layer F.Fab) (width 0.1))
   (fp_line (start -2.25 -1.75) (end -2.25 5.75) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 4) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D12mm_W7.5mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D12mm_W7.9mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D12mm_W7.9mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2.25 -1.75) (end 9.75 -1.75) (layer F.Fab) (width 0.1))
   (fp_line (start 9.75 -1.75) (end 9.75 6.15) (layer F.Fab) (width 0.1))
   (fp_line (start -2.25 -1.75) (end -2.25 6.15) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 4.4) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D12mm_W7.9mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D15.5mm_W11mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D15.5mm_W11mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -4 -2.15) (end 11.5 -2.15) (layer F.Fab) (width 0.1))
   (fp_line (start 11.5 -2.15) (end 11.5 8.85) (layer F.Fab) (width 0.1))
   (fp_line (start -4 -2.15) (end -4 8.85) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 6.7) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D15.5mm_W11mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D15.5mm_W3.9mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D15.5mm_W3.9mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -4 -1.25) (end 11.5 -1.25) (layer F.Fab) (width 0.1))
   (fp_line (start 11.5 -1.25) (end 11.5 2.65) (layer F.Fab) (width 0.1))
   (fp_line (start -4 -1.25) (end -4 2.65) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 1.4) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D15.5mm_W3.9mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D15.5mm_W4.2mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D15.5mm_W4.2mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -4 -1.25) (end 11.5 -1.25) (layer F.Fab) (width 0.1))
   (fp_line (start 11.5 -1.25) (end 11.5 2.95) (layer F.Fab) (width 0.1))
   (fp_line (start -4 -1.25) (end -4 2.95) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 1.7) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D15.5mm_W4.2mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D15.5mm_W4.3mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D15.5mm_W4.3mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -4 -1.15) (end 11.5 -1.15) (layer F.Fab) (width 0.1))
   (fp_line (start 11.5 -1.15) (end 11.5 3.15) (layer F.Fab) (width 0.1))
   (fp_line (start -4 -1.15) (end -4 3.15) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 2) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D15.5mm_W4.3mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D15.5mm_W4.4mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D15.5mm_W4.4mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -4 -1.26667) (end 11.5 -1.26667) (layer F.Fab) (width 0.1))
   (fp_line (start 11.5 -1.26667) (end 11.5 3.13333) (layer F.Fab) (width 0.1))
   (fp_line (start -4 -1.26667) (end -4 3.13333) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 1.86667) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D15.5mm_W4.4mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D15.5mm_W4.5mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D15.5mm_W4.5mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -4 -1.25) (end 11.5 -1.25) (layer F.Fab) (width 0.1))
   (fp_line (start 11.5 -1.25) (end 11.5 3.25) (layer F.Fab) (width 0.1))
   (fp_line (start -4 -1.25) (end -4 3.25) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 2) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D15.5mm_W4.5mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D15.5mm_W4.6mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D15.5mm_W4.6mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -4 -1.275) (end 11.5 -1.275) (layer F.Fab) (width 0.1))
   (fp_line (start 11.5 -1.275) (end 11.5 3.325) (layer F.Fab) (width 0.1))
   (fp_line (start -4 -1.275) (end -4 3.325) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 2.05) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D15.5mm_W4.6mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D15.5mm_W4.7mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D15.5mm_W4.7mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -4 -1.35) (end 11.5 -1.35) (layer F.Fab) (width 0.1))
   (fp_line (start 11.5 -1.35) (end 11.5 3.35) (layer F.Fab) (width 0.1))
   (fp_line (start -4 -1.35) (end -4 3.35) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 2) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D15.5mm_W4.7mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D15.5mm_W4.8mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D15.5mm_W4.8mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -4 -1.4) (end 11.5 -1.4) (layer F.Fab) (width 0.1))
   (fp_line (start 11.5 -1.4) (end 11.5 3.4) (layer F.Fab) (width 0.1))
   (fp_line (start -4 -1.4) (end -4 3.4) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 2) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D15.5mm_W4.8mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D15.5mm_W4.9mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D15.5mm_W4.9mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -4 -1.35) (end 11.5 -1.35) (layer F.Fab) (width 0.1))
   (fp_line (start 11.5 -1.35) (end 11.5 3.55) (layer F.Fab) (width 0.1))
   (fp_line (start -4 -1.35) (end -4 3.55) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 2.2) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D15.5mm_W4.9mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D15.5mm_W4mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D15.5mm_W4mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -4 -1.275) (end 11.5 -1.275) (layer F.Fab) (width 0.1))
   (fp_line (start 11.5 -1.275) (end 11.5 2.725) (layer F.Fab) (width 0.1))
   (fp_line (start -4 -1.275) (end -4 2.725) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 1.45) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D15.5mm_W4mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D15.5mm_W5.2mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D15.5mm_W5.2mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -4 -1.45) (end 11.5 -1.45) (layer F.Fab) (width 0.1))
   (fp_line (start 11.5 -1.45) (end 11.5 3.75) (layer F.Fab) (width 0.1))
   (fp_line (start -4 -1.45) (end -4 3.75) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 2.3) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D15.5mm_W5.2mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D15.5mm_W5.4mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D15.5mm_W5.4mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -4 -1.5) (end 11.5 -1.5) (layer F.Fab) (width 0.1))
   (fp_line (start 11.5 -1.5) (end 11.5 3.9) (layer F.Fab) (width 0.1))
   (fp_line (start -4 -1.5) (end -4 3.9) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 2.4) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D15.5mm_W5.4mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D15.5mm_W5.9mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D15.5mm_W5.9mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -4 -1.6) (end 11.5 -1.6) (layer F.Fab) (width 0.1))
   (fp_line (start 11.5 -1.6) (end 11.5 4.3) (layer F.Fab) (width 0.1))
   (fp_line (start -4 -1.6) (end -4 4.3) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 2.7) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D15.5mm_W5.9mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D15.5mm_W5mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D15.5mm_W5mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -4 -1.4) (end 11.5 -1.4) (layer F.Fab) (width 0.1))
   (fp_line (start 11.5 -1.4) (end 11.5 3.6) (layer F.Fab) (width 0.1))
   (fp_line (start -4 -1.4) (end -4 3.6) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 2.2) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D15.5mm_W5mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D15.5mm_W6.1mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D15.5mm_W6.1mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -4 -1.6) (end 11.5 -1.6) (layer F.Fab) (width 0.1))
   (fp_line (start 11.5 -1.6) (end 11.5 4.5) (layer F.Fab) (width 0.1))
   (fp_line (start -4 -1.6) (end -4 4.5) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 2.9) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D15.5mm_W6.1mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D15.5mm_W6.3mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D15.5mm_W6.3mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -4 -1.65) (end 11.5 -1.65) (layer F.Fab) (width 0.1))
   (fp_line (start 11.5 -1.65) (end 11.5 4.65) (layer F.Fab) (width 0.1))
   (fp_line (start -4 -1.65) (end -4 4.65) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 3) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D15.5mm_W6.3mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D15.5mm_W6.4mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D15.5mm_W6.4mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -4 -1.65) (end 11.5 -1.65) (layer F.Fab) (width 0.1))
   (fp_line (start 11.5 -1.65) (end 11.5 4.75) (layer F.Fab) (width 0.1))
   (fp_line (start -4 -1.65) (end -4 4.75) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 3.1) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D15.5mm_W6.4mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D15.5mm_W6.8mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D15.5mm_W6.8mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -4 -1.7) (end 11.5 -1.7) (layer F.Fab) (width 0.1))
   (fp_line (start 11.5 -1.7) (end 11.5 5.1) (layer F.Fab) (width 0.1))
   (fp_line (start -4 -1.7) (end -4 5.1) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 3.4) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D15.5mm_W6.8mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D15.5mm_W7.2mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D15.5mm_W7.2mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -4 -1.75) (end 11.5 -1.75) (layer F.Fab) (width 0.1))
   (fp_line (start 11.5 -1.75) (end 11.5 5.45) (layer F.Fab) (width 0.1))
   (fp_line (start -4 -1.75) (end -4 5.45) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 3.7) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D15.5mm_W7.2mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D15.5mm_W7.5mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D15.5mm_W7.5mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -4 -1.75) (end 11.5 -1.75) (layer F.Fab) (width 0.1))
   (fp_line (start 11.5 -1.75) (end 11.5 5.75) (layer F.Fab) (width 0.1))
   (fp_line (start -4 -1.75) (end -4 5.75) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 4) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D15.5mm_W7.5mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D15.5mm_W8mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D15.5mm_W8mm_P7.5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -4 -1.8) (end 11.5 -1.8) (layer F.Fab) (width 0.1))
   (fp_line (start 11.5 -1.8) (end 11.5 6.2) (layer F.Fab) (width 0.1))
   (fp_line (start -4 -1.8) (end -4 6.2) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 4.4) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D15.5mm_W8mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D21.5mm_W11.4mm_P10mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D21.5mm_W11.4mm_P10mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -5.75 -2.25) (end 15.75 -2.25) (layer F.Fab) (width 0.1))
   (fp_line (start 15.75 -2.25) (end 15.75 9.15) (layer F.Fab) (width 0.1))
   (fp_line (start -5.75 -2.25) (end -5.75 9.15) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 6.9) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D21.5mm_W11.4mm_P10mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D21.5mm_W4.3mm_P10mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D21.5mm_W4.3mm_P10mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -5.75 -1.4) (end 15.75 -1.4) (layer F.Fab) (width 0.1))
   (fp_line (start 15.75 -1.4) (end 15.75 2.9) (layer F.Fab) (width 0.1))
   (fp_line (start -5.75 -1.4) (end -5.75 2.9) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 1.5) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D21.5mm_W4.3mm_P10mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D21.5mm_W4.4mm_P10mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D21.5mm_W4.4mm_P10mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -5.75 -1.4) (end 15.75 -1.4) (layer F.Fab) (width 0.1))
   (fp_line (start 15.75 -1.4) (end 15.75 3) (layer F.Fab) (width 0.1))
   (fp_line (start -5.75 -1.4) (end -5.75 3) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 1.6) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D21.5mm_W4.4mm_P10mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D21.5mm_W4.5mm_P10mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D21.5mm_W4.5mm_P10mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -5.75 -1.475) (end 15.75 -1.475) (layer F.Fab) (width 0.1))
   (fp_line (start 15.75 -1.475) (end 15.75 3.025) (layer F.Fab) (width 0.1))
   (fp_line (start -5.75 -1.475) (end -5.75 3.025) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 1.55) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D21.5mm_W4.5mm_P10mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D21.5mm_W4.6mm_P10mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D21.5mm_W4.6mm_P10mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -5.75 -1.45) (end 15.75 -1.45) (layer F.Fab) (width 0.1))
   (fp_line (start 15.75 -1.45) (end 15.75 3.15) (layer F.Fab) (width 0.1))
   (fp_line (start -5.75 -1.45) (end -5.75 3.15) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 1.7) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D21.5mm_W4.6mm_P10mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D21.5mm_W4.7mm_P10mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D21.5mm_W4.7mm_P10mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -5.75 -1.4) (end 15.75 -1.4) (layer F.Fab) (width 0.1))
   (fp_line (start 15.75 -1.4) (end 15.75 3.3) (layer F.Fab) (width 0.1))
   (fp_line (start -5.75 -1.4) (end -5.75 3.3) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 1.9) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D21.5mm_W4.7mm_P10mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D21.5mm_W4.8mm_P10mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D21.5mm_W4.8mm_P10mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -5.75 -1.425) (end 15.75 -1.425) (layer F.Fab) (width 0.1))
   (fp_line (start 15.75 -1.425) (end 15.75 3.375) (layer F.Fab) (width 0.1))
   (fp_line (start -5.75 -1.425) (end -5.75 3.375) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 1.95) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D21.5mm_W4.8mm_P10mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D21.5mm_W4.9mm_P10mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D21.5mm_W4.9mm_P10mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -5.75 -1.4) (end 15.75 -1.4) (layer F.Fab) (width 0.1))
   (fp_line (start 15.75 -1.4) (end 15.75 3.5) (layer F.Fab) (width 0.1))
   (fp_line (start -5.75 -1.4) (end -5.75 3.5) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 2.1) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D21.5mm_W4.9mm_P10mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D21.5mm_W5.1mm_P10mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D21.5mm_W5.1mm_P10mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -5.75 -1.475) (end 15.75 -1.475) (layer F.Fab) (width 0.1))
   (fp_line (start 15.75 -1.475) (end 15.75 3.625) (layer F.Fab) (width 0.1))
   (fp_line (start -5.75 -1.475) (end -5.75 3.625) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 2.15) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D21.5mm_W5.1mm_P10mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D21.5mm_W5.3mm_P10mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D21.5mm_W5.3mm_P10mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -5.75 -1.55) (end 15.75 -1.55) (layer F.Fab) (width 0.1))
   (fp_line (start 15.75 -1.55) (end 15.75 3.75) (layer F.Fab) (width 0.1))
   (fp_line (start -5.75 -1.55) (end -5.75 3.75) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 2.2) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D21.5mm_W5.3mm_P10mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D21.5mm_W5.4mm_P10mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D21.5mm_W5.4mm_P10mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -5.75 -1.525) (end 15.75 -1.525) (layer F.Fab) (width 0.1))
   (fp_line (start 15.75 -1.525) (end 15.75 3.875) (layer F.Fab) (width 0.1))
   (fp_line (start -5.75 -1.525) (end -5.75 3.875) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 2.35) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D21.5mm_W5.4mm_P10mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D21.5mm_W5.6mm_P10mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D21.5mm_W5.6mm_P10mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -5.75 -1.6) (end 15.75 -1.6) (layer F.Fab) (width 0.1))
   (fp_line (start 15.75 -1.6) (end 15.75 4) (layer F.Fab) (width 0.1))
   (fp_line (start -5.75 -1.6) (end -5.75 4) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 2.4) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D21.5mm_W5.6mm_P10mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D21.5mm_W5.8mm_P10mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D21.5mm_W5.8mm_P10mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -5.75 -1.6) (end 15.75 -1.6) (layer F.Fab) (width 0.1))
   (fp_line (start 15.75 -1.6) (end 15.75 4.2) (layer F.Fab) (width 0.1))
   (fp_line (start -5.75 -1.6) (end -5.75 4.2) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 2.6) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D21.5mm_W5.8mm_P10mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D21.5mm_W5mm_P10mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D21.5mm_W5mm_P10mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -5.75 -1.35) (end 15.75 -1.35) (layer F.Fab) (width 0.1))
   (fp_line (start 15.75 -1.35) (end 15.75 3.65) (layer F.Fab) (width 0.1))
   (fp_line (start -5.75 -1.35) (end -5.75 3.65) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 2.3) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D21.5mm_W5mm_P10mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D21.5mm_W6.1mm_P7.5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D21.5mm_W6.1mm_P7.5mm.kicad_mod
@@ -26,6 +26,6 @@
   (fp_line (start -7 -1.6) (end 14.5 -1.6) (layer F.Fab) (width 0.1))
   (fp_line (start 14.5 -1.6) (end 14.5 4.5) (layer F.Fab) (width 0.1))
   (fp_line (start -7 -1.6) (end -7 4.5) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 7.5 2.9) (size 1.8 1.8) (drill 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D21.5mm_W6.1mm_P7.5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D21.5mm_W6.3mm_P10mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D21.5mm_W6.3mm_P10mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -5.75 -1.75) (end 15.75 -1.75) (layer F.Fab) (width 0.1))
   (fp_line (start 15.75 -1.75) (end 15.75 4.55) (layer F.Fab) (width 0.1))
   (fp_line (start -5.75 -1.75) (end -5.75 4.55) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 2.8) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D21.5mm_W6.3mm_P10mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D21.5mm_W6.5mm_P10mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D21.5mm_W6.5mm_P10mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -5.75 -1.7) (end 15.75 -1.7) (layer F.Fab) (width 0.1))
   (fp_line (start 15.75 -1.7) (end 15.75 4.8) (layer F.Fab) (width 0.1))
   (fp_line (start -5.75 -1.7) (end -5.75 4.8) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 3.1) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D21.5mm_W6.5mm_P10mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D21.5mm_W6.7mm_P10mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D21.5mm_W6.7mm_P10mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -5.75 -1.8) (end 15.75 -1.8) (layer F.Fab) (width 0.1))
   (fp_line (start 15.75 -1.8) (end 15.75 4.9) (layer F.Fab) (width 0.1))
   (fp_line (start -5.75 -1.8) (end -5.75 4.9) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 3.1) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D21.5mm_W6.7mm_P10mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D21.5mm_W6.8mm_P10mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D21.5mm_W6.8mm_P10mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -5.75 -1.75) (end 15.75 -1.75) (layer F.Fab) (width 0.1))
   (fp_line (start 15.75 -1.75) (end 15.75 5.05) (layer F.Fab) (width 0.1))
   (fp_line (start -5.75 -1.75) (end -5.75 5.05) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 3.3) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D21.5mm_W6.8mm_P10mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D21.5mm_W7.1mm_P10mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D21.5mm_W7.1mm_P10mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -5.75 -1.8) (end 15.75 -1.8) (layer F.Fab) (width 0.1))
   (fp_line (start 15.75 -1.8) (end 15.75 5.3) (layer F.Fab) (width 0.1))
   (fp_line (start -5.75 -1.8) (end -5.75 5.3) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 3.5) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D21.5mm_W7.1mm_P10mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D21.5mm_W7.5mm_P10mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D21.5mm_W7.5mm_P10mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -5.75 -1.8) (end 15.75 -1.8) (layer F.Fab) (width 0.1))
   (fp_line (start 15.75 -1.8) (end 15.75 5.7) (layer F.Fab) (width 0.1))
   (fp_line (start -5.75 -1.8) (end -5.75 5.7) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 3.9) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D21.5mm_W7.5mm_P10mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D21.5mm_W7.9mm_P10mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D21.5mm_W7.9mm_P10mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -5.75 -1.85) (end 15.75 -1.85) (layer F.Fab) (width 0.1))
   (fp_line (start 15.75 -1.85) (end 15.75 6.05) (layer F.Fab) (width 0.1))
   (fp_line (start -5.75 -1.85) (end -5.75 6.05) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 4.2) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D21.5mm_W7.9mm_P10mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D21.5mm_W8.4mm_P10mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D21.5mm_W8.4mm_P10mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -5.75 -1.95) (end 15.75 -1.95) (layer F.Fab) (width 0.1))
   (fp_line (start 15.75 -1.95) (end 15.75 6.45) (layer F.Fab) (width 0.1))
   (fp_line (start -5.75 -1.95) (end -5.75 6.45) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 10 4.5) (size 2 2) (drill 1) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D21.5mm_W8.4mm_P10mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D7mm_W3.4mm_P5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D7mm_W3.4mm_P5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -1 -1.05) (end 6 -1.05) (layer F.Fab) (width 0.1))
   (fp_line (start 6 -1.05) (end 6 2.35) (layer F.Fab) (width 0.1))
   (fp_line (start -1 -1.05) (end -1 2.35) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 1.3) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D7mm_W3.4mm_P5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D7mm_W3.5mm_P5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D7mm_W3.5mm_P5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -1 -1.1) (end 6 -1.1) (layer F.Fab) (width 0.1))
   (fp_line (start 6 -1.1) (end 6 2.4) (layer F.Fab) (width 0.1))
   (fp_line (start -1 -1.1) (end -1 2.4) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 1.3) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D7mm_W3.5mm_P5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D7mm_W3.6mm_P5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D7mm_W3.6mm_P5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -1 -1.06667) (end 6 -1.06667) (layer F.Fab) (width 0.1))
   (fp_line (start 6 -1.06667) (end 6 2.53333) (layer F.Fab) (width 0.1))
   (fp_line (start -1 -1.06667) (end -1 2.53333) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 1.46667) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D7mm_W3.6mm_P5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D7mm_W3.7mm_P5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D7mm_W3.7mm_P5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -1 -1.025) (end 6 -1.025) (layer F.Fab) (width 0.1))
   (fp_line (start 6 -1.025) (end 6 2.675) (layer F.Fab) (width 0.1))
   (fp_line (start -1 -1.025) (end -1 2.675) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 1.65) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D7mm_W3.7mm_P5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D7mm_W3.8mm_P5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D7mm_W3.8mm_P5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -1 -1) (end 6 -1) (layer F.Fab) (width 0.1))
   (fp_line (start 6 -1) (end 6 2.8) (layer F.Fab) (width 0.1))
   (fp_line (start -1 -1) (end -1 2.8) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 1.8) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D7mm_W3.8mm_P5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D7mm_W3.9mm_P5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D7mm_W3.9mm_P5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -1 -1) (end 6 -1) (layer F.Fab) (width 0.1))
   (fp_line (start 6 -1) (end 6 2.9) (layer F.Fab) (width 0.1))
   (fp_line (start -1 -1) (end -1 2.9) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 1.9) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D7mm_W3.9mm_P5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D7mm_W4.2mm_P5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D7mm_W4.2mm_P5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -1 -1.2) (end 6 -1.2) (layer F.Fab) (width 0.1))
   (fp_line (start 6 -1.2) (end 6 3) (layer F.Fab) (width 0.1))
   (fp_line (start -1 -1.2) (end -1 3) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 1.8) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D7mm_W4.2mm_P5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D7mm_W4.3mm_P5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D7mm_W4.3mm_P5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -1 -1.15) (end 6 -1.15) (layer F.Fab) (width 0.1))
   (fp_line (start 6 -1.15) (end 6 3.15) (layer F.Fab) (width 0.1))
   (fp_line (start -1 -1.15) (end -1 3.15) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 2) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D7mm_W4.3mm_P5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D7mm_W4.5mm_P5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D7mm_W4.5mm_P5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -1 -1.2) (end 6 -1.2) (layer F.Fab) (width 0.1))
   (fp_line (start 6 -1.2) (end 6 3.3) (layer F.Fab) (width 0.1))
   (fp_line (start -1 -1.2) (end -1 3.3) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 2.1) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D7mm_W4.5mm_P5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D7mm_W4.8mm_P5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D7mm_W4.8mm_P5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -1 -1.25) (end 6 -1.25) (layer F.Fab) (width 0.1))
   (fp_line (start 6 -1.25) (end 6 3.55) (layer F.Fab) (width 0.1))
   (fp_line (start -1 -1.25) (end -1 3.55) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 2.3) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D7mm_W4.8mm_P5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D7mm_W4mm_P5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D7mm_W4mm_P5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -1 -1.1) (end 6 -1.1) (layer F.Fab) (width 0.1))
   (fp_line (start 6 -1.1) (end 6 2.9) (layer F.Fab) (width 0.1))
   (fp_line (start -1 -1.1) (end -1 2.9) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 1.8) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D7mm_W4mm_P5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D7mm_W5.1mm_P5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D7mm_W5.1mm_P5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -1 -1.3) (end 6 -1.3) (layer F.Fab) (width 0.1))
   (fp_line (start 6 -1.3) (end 6 3.8) (layer F.Fab) (width 0.1))
   (fp_line (start -1 -1.3) (end -1 3.8) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 2.5) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D7mm_W5.1mm_P5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D7mm_W5.4mm_P5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D7mm_W5.4mm_P5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -1 -1.3) (end 6 -1.3) (layer F.Fab) (width 0.1))
   (fp_line (start 6 -1.3) (end 6 4.1) (layer F.Fab) (width 0.1))
   (fp_line (start -1 -1.3) (end -1 4.1) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 2.8) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D7mm_W5.4mm_P5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D7mm_W5.5mm_P5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D7mm_W5.5mm_P5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -1 -1.35) (end 6 -1.35) (layer F.Fab) (width 0.1))
   (fp_line (start 6 -1.35) (end 6 4.15) (layer F.Fab) (width 0.1))
   (fp_line (start -1 -1.35) (end -1 4.15) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 2.8) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D7mm_W5.5mm_P5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D7mm_W5.7mm_P5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D7mm_W5.7mm_P5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -1 -1.35) (end 6 -1.35) (layer F.Fab) (width 0.1))
   (fp_line (start 6 -1.35) (end 6 4.35) (layer F.Fab) (width 0.1))
   (fp_line (start -1 -1.35) (end -1 4.35) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 3) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D7mm_W5.7mm_P5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D9mm_W3.3mm_P5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D9mm_W3.3mm_P5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2 -1.05) (end 7 -1.05) (layer F.Fab) (width 0.1))
   (fp_line (start 7 -1.05) (end 7 2.25) (layer F.Fab) (width 0.1))
   (fp_line (start -2 -1.05) (end -2 2.25) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 1.2) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D9mm_W3.3mm_P5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D9mm_W3.4mm_P5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D9mm_W3.4mm_P5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2 -1.075) (end 7 -1.075) (layer F.Fab) (width 0.1))
   (fp_line (start 7 -1.075) (end 7 2.325) (layer F.Fab) (width 0.1))
   (fp_line (start -2 -1.075) (end -2 2.325) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 1.25) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D9mm_W3.4mm_P5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D9mm_W3.5mm_P5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D9mm_W3.5mm_P5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2 -1.1) (end 7 -1.1) (layer F.Fab) (width 0.1))
   (fp_line (start 7 -1.1) (end 7 2.4) (layer F.Fab) (width 0.1))
   (fp_line (start -2 -1.1) (end -2 2.4) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 1.3) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D9mm_W3.5mm_P5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D9mm_W3.6mm_P5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D9mm_W3.6mm_P5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2 -1.1) (end 7 -1.1) (layer F.Fab) (width 0.1))
   (fp_line (start 7 -1.1) (end 7 2.5) (layer F.Fab) (width 0.1))
   (fp_line (start -2 -1.1) (end -2 2.5) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 1.4) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D9mm_W3.6mm_P5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D9mm_W3.7mm_P5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D9mm_W3.7mm_P5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2 -1.1) (end 7 -1.1) (layer F.Fab) (width 0.1))
   (fp_line (start 7 -1.1) (end 7 2.6) (layer F.Fab) (width 0.1))
   (fp_line (start -2 -1.1) (end -2 2.6) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 1.5) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D9mm_W3.7mm_P5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D9mm_W3.8mm_P5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D9mm_W3.8mm_P5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2 -1) (end 7 -1) (layer F.Fab) (width 0.1))
   (fp_line (start 7 -1) (end 7 2.8) (layer F.Fab) (width 0.1))
   (fp_line (start -2 -1) (end -2 2.8) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 1.8) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D9mm_W3.8mm_P5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D9mm_W3.9mm_P5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D9mm_W3.9mm_P5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2 -1.15) (end 7 -1.15) (layer F.Fab) (width 0.1))
   (fp_line (start 7 -1.15) (end 7 2.75) (layer F.Fab) (width 0.1))
   (fp_line (start -2 -1.15) (end -2 2.75) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 1.6) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D9mm_W3.9mm_P5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D9mm_W4.1mm_P5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D9mm_W4.1mm_P5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2 -1.15) (end 7 -1.15) (layer F.Fab) (width 0.1))
   (fp_line (start 7 -1.15) (end 7 2.95) (layer F.Fab) (width 0.1))
   (fp_line (start -2 -1.15) (end -2 2.95) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 1.8) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D9mm_W4.1mm_P5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D9mm_W4.2mm_P5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D9mm_W4.2mm_P5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2 -1.2) (end 7 -1.2) (layer F.Fab) (width 0.1))
   (fp_line (start 7 -1.2) (end 7 3) (layer F.Fab) (width 0.1))
   (fp_line (start -2 -1.2) (end -2 3) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 1.8) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D9mm_W4.2mm_P5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D9mm_W4.4mm_P5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D9mm_W4.4mm_P5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2 -1.2) (end 7 -1.2) (layer F.Fab) (width 0.1))
   (fp_line (start 7 -1.2) (end 7 3.2) (layer F.Fab) (width 0.1))
   (fp_line (start -2 -1.2) (end -2 3.2) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 2) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D9mm_W4.4mm_P5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D9mm_W4.5mm_P5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D9mm_W4.5mm_P5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2 -1.2) (end 7 -1.2) (layer F.Fab) (width 0.1))
   (fp_line (start 7 -1.2) (end 7 3.3) (layer F.Fab) (width 0.1))
   (fp_line (start -2 -1.2) (end -2 3.3) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 2.1) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D9mm_W4.5mm_P5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D9mm_W4.8mm_P5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D9mm_W4.8mm_P5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2 -1.25) (end 7 -1.25) (layer F.Fab) (width 0.1))
   (fp_line (start 7 -1.25) (end 7 3.55) (layer F.Fab) (width 0.1))
   (fp_line (start -2 -1.25) (end -2 3.55) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 2.3) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D9mm_W4.8mm_P5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D9mm_W4mm_P5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D9mm_W4mm_P5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2 -1.05) (end 7 -1.05) (layer F.Fab) (width 0.1))
   (fp_line (start 7 -1.05) (end 7 2.95) (layer F.Fab) (width 0.1))
   (fp_line (start -2 -1.05) (end -2 2.95) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 1.9) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D9mm_W4mm_P5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D9mm_W5.2mm_P5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D9mm_W5.2mm_P5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2 -1.35) (end 7 -1.35) (layer F.Fab) (width 0.1))
   (fp_line (start 7 -1.35) (end 7 3.85) (layer F.Fab) (width 0.1))
   (fp_line (start -2 -1.35) (end -2 3.85) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 2.5) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D9mm_W5.2mm_P5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D9mm_W5.4mm_P5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D9mm_W5.4mm_P5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2 -1.3) (end 7 -1.3) (layer F.Fab) (width 0.1))
   (fp_line (start 7 -1.3) (end 7 4.1) (layer F.Fab) (width 0.1))
   (fp_line (start -2 -1.3) (end -2 4.1) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 2.8) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D9mm_W5.4mm_P5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D9mm_W5.5mm_P5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D9mm_W5.5mm_P5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2 -1.35) (end 7 -1.35) (layer F.Fab) (width 0.1))
   (fp_line (start 7 -1.35) (end 7 4.15) (layer F.Fab) (width 0.1))
   (fp_line (start -2 -1.35) (end -2 4.15) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 2.8) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D9mm_W5.5mm_P5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))

--- a/Varistor.pretty/RV_Disc_D9mm_W5.7mm_P5mm.kicad_mod
+++ b/Varistor.pretty/RV_Disc_D9mm_W5.7mm_P5mm.kicad_mod
@@ -22,6 +22,6 @@
   (fp_line (start -2 -1.35) (end 7 -1.35) (layer F.Fab) (width 0.1))
   (fp_line (start 7 -1.35) (end 7 4.35) (layer F.Fab) (width 0.1))
   (fp_line (start -2 -1.35) (end -2 4.35) (layer F.Fab) (width 0.1))
-  (pad 1 thru_hole rect (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 5 3) (size 1.6 1.6) (drill 0.6) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Varistor.3dshapes/RV_Disc_D9mm_W5.7mm_P5mm.wrl    (at (xyz 0 0 0))    (scale (xyz 1 1 1))    (rotate (xyz 0 0 0))  ))


### PR DESCRIPTION
Commit 2e41670373493a62d1f8f3876b11526354db669e mistakenly changed the varistor symbols to use square pads for pin 1.  This commit reverts that change, as varistors are non-polarized devices.

Fixes #377.

------------

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the footprint(s) you are contributing
- [ ] An example screenshot image is very helpful 
- [ ] If there are matching symbol or 3D model pull requests, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
