### PR TITLE
Set Travis to use Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+language: python
+python:
+  - "2.7"
 
 before_install:
 - git clone --depth 1 https://github.com/KiCad/kicad-library-utils /home/travis/build/kicad-library-utils


### PR DESCRIPTION
The default language is Ruby, which causes Travis to waste about four seconds setting up a Ruby environment we don't need every time CI is run. This PR changes the language to the one we actually use, Python 2.7.

Like https://github.com/KiCad/kicad-symbols/pull/370, but with a cleaner commit history because I already figured out what needs to be done.