### PR TITLE
Remove sudo from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ before_install:
 - git clone --depth 1 https://github.com/KiCad/kicad-library-utils /home/travis/build/kicad-library-utils
 
 script:
-- sudo bash /home/travis/build/kicad-library-utils/pcb/travis/check_all.sh $TRAVIS_BUILD_DIR -v
+- bash /home/travis/build/kicad-library-utils/pcb/travis/check_all.sh $TRAVIS_BUILD_DIR -v
 - python /home/travis/build/kicad-library-utils/check_lib_table.py $TRAVIS_BUILD_DIR/*.pretty --table $TRAVIS_BUILD_DIR/fp-lib-table


### PR DESCRIPTION
There were [claims](https://github.com/KiCad/kicad-footprints/issues/46) in the past that the `sudo` in the Travis CI script was needed for some unknown reason.  I just did some testing on my own fork of kicad-footprints and found that it made absolutely no functional difference whether the `check_all.sh` script was run with `sudo` or not.  Not using `sudo` also gave a decent speedup (see [below](https://github.com/KiCad/kicad-footprints/pull/424#issuecomment-372709337)).  This PR removes it, running the `check_all.sh` script as a normal user.

Fixes https://github.com/KiCad/kicad-library-utils/issues/177.