### PR TITLE
Change TI_ prefix to Texas_ for X2SON footprint

### DIFF
--- a/Package_SON.pretty/Texas_X2SON-4_1x1mm_P0.65mm.kicad_mod
+++ b/Package_SON.pretty/Texas_X2SON-4_1x1mm_P0.65mm.kicad_mod
@@ -1,11 +1,11 @@
-(module TI_X2SON-4_1x1mm_P0.65mm (layer F.Cu) (tedit 5A02F1D8)
-  (descr "X2SON-4 1x1mm Pitch0.65mm (http://www.ti.com/lit/ds/sbvs193d/sbvs193d.pdf)")
+(module Texas_X2SON-4_1x1mm_P0.65mm (layer F.Cu) (tedit 5A02F1D8)
+  (descr "Texas Instruments X2SON-4 1x1mm Pitch0.65mm (http://www.ti.com/lit/ds/sbvs193d/sbvs193d.pdf)")
   (tags "X2SON-4 1x1mm Pitch0.65mm")
   (attr smd)
   (fp_text reference REF** (at 0 -1.4) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (fp_text value TI_X2SON-4_1x1mm_P0.65mm (at 0 1.4) (layer F.Fab)
+  (fp_text value Texas_X2SON-4_1x1mm_P0.65mm (at 0 1.4) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
   (fp_text user %R (at 0 0) (layer F.Fab)
@@ -102,7 +102,7 @@
     (solder_mask_margin 0.001))
   (pad "" smd trapezoid (at 0.45 -0.31 180) (size 0.2 0.18) (rect_delta 0 0.1999 ) (layers F.Paste)
     (solder_mask_margin 0.001))
-  (model ${KISYS3DMOD}/Package_SON.3dshapes/TI_X2SON-4_1x1mm_P0.65mm.wrl
+  (model ${KISYS3DMOD}/Package_SON.3dshapes/Texas_X2SON-4_1x1mm_P0.65mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))


### PR DESCRIPTION
Just what it says. Check all the other repos, including this one, to see Texas_ is used everywhere else.

Noted by https://github.com/KiCad/kicad-symbols/pull/386.

------------

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the footprint(s) you are contributing
- [ ] An example screenshot image is very helpful 
- [ ] If there are matching symbol or 3D model pull requests, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
