### PR TITLE
Fix footprint names in Sensor_Current lib (Pitch -> P)

### DIFF
--- a/Sensor_Current.pretty/AKM_CQ_VSOP-24_5.6x7.9mm_P0.65mm.kicad_mod
+++ b/Sensor_Current.pretty/AKM_CQ_VSOP-24_5.6x7.9mm_P0.65mm.kicad_mod
@@ -1,11 +1,11 @@
-(module AKM_CQ_VSOP-24_5.6x7.9mm_Pitch0.65mm (layer F.Cu) (tedit 59DD6446)
+(module AKM_CQ_VSOP-24_5.6x7.9mm_P0.65mm (layer F.Cu) (tedit 5AE4B758)
   (descr "AKM VSOP-24 current sensor, 5.6x7.9mm body, 0.65mm pitch (http://www.akm.com/akm/en/file/datasheet/CQ-330J.pdf)")
   (tags "akm vsop 24")
   (attr smd)
   (fp_text reference REF** (at 0 -4.9) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (fp_text value AKM_CQ_VSOP-24_5.6x7.9mm_Pitch0.65mm (at 0 4.9) (layer F.Fab)
+  (fp_text value AKM_CQ_VSOP-24_5.6x7.9mm_P0.65mm (at 0 4.9) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
   (fp_text user %R (at 0 0) (layer F.Fab)
@@ -32,7 +32,7 @@
   (pad 10 smd rect (at 3.81 -1.95) (size 1.42 3.6) (layers F.Cu F.Paste F.Mask))
   (pad 9 smd rect (at 3.81 1.95) (size 1.42 3.6) (layers F.Cu F.Paste F.Mask))
   (pad 8 smd rect (at -3.81 2.925) (size 1.42 1.65) (layers F.Cu F.Paste F.Mask))
-  (model ${KISYS3DMOD}/Sensor_Current.3dshapes/AKM_CQ_VSOP-24_5.6x7.9mm_Pitch0.65mm.wrl
+  (model ${KISYS3DMOD}/Sensor_Current.3dshapes/AKM_CQ_VSOP-24_5.6x7.9mm_P0.65mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/Sensor_Current.pretty/AKM_CZ_SSOP-10_6.5x8.1mm_P0.95mm.kicad_mod
+++ b/Sensor_Current.pretty/AKM_CZ_SSOP-10_6.5x8.1mm_P0.95mm.kicad_mod
@@ -1,11 +1,11 @@
-(module AKM_CZ_SSOP-10_6.5x8.1mm_Pitch0.95mm (layer F.Cu) (tedit 59E6559D)
+(module AKM_CZ_SSOP-10_6.5x8.1mm_P0.95mm (layer F.Cu) (tedit 5AE4B798)
   (descr "AKM CZ-381x current sensor, 6.5x8.1mm body, 0.95mm pitch (http://www.akm.com/akm/en/product/detail/0009/)")
   (tags "akm cz-381x 10")
   (attr smd)
   (fp_text reference REF** (at 0 -5) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (fp_text value AKM_CZ_SSOP-10_6.5x8.1mm_Pitch0.95mm (at 0 5) (layer F.Fab)
+  (fp_text value AKM_CZ_SSOP-10_6.5x8.1mm_P0.95mm (at 0 5) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
   (fp_text user %R (at 0 0) (layer F.Fab)
@@ -34,7 +34,7 @@
   (pad 6 smd rect (at -5.29 1.425) (size 1.42 0.54) (layers F.Cu F.Paste F.Mask))
   (pad 7 smd rect (at -5.29 2.375) (size 1.42 0.54) (layers F.Cu F.Paste F.Mask))
   (pad 8 smd rect (at -5.29 3.325) (size 1.42 0.54) (layers F.Cu F.Paste F.Mask))
-  (model ${KISYS3DMOD}/Sensor_Current.3dshapes/AKM_CZ_SSOP-10_6.5x8.1mm_Pitch0.95mm.wrl
+  (model ${KISYS3DMOD}/Sensor_Current.3dshapes/AKM_CZ_SSOP-10_6.5x8.1mm_P0.95mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/Sensor_Current.pretty/Allegro_PSOF-7_4.8x6.4mm_P1.60mm.kicad_mod
+++ b/Sensor_Current.pretty/Allegro_PSOF-7_4.8x6.4mm_P1.60mm.kicad_mod
@@ -1,11 +1,11 @@
-(module Allegro_PSOF-7_4.8x6.4mm_Pitch1.60mm (layer F.Cu) (tedit 5A04B58C)
+(module Allegro_PSOF-7_4.8x6.4mm_P1.60mm (layer F.Cu) (tedit 5AE4B6CE)
   (descr "Allegro Microsystems PSOF-7, 4.8x6.4mm Body, 1.60mm Pitch (http://www.allegromicro.com/~/media/Files/Datasheets/ACS780-Datasheet.ashx)")
   (tags "Allegro PSOF-7")
   (attr smd)
   (fp_text reference REF** (at 0 -4.2) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (fp_text value Allegro_PSOF-7_4.8x6.4mm_Pitch1.60mm (at 0 4.2) (layer F.Fab)
+  (fp_text value Allegro_PSOF-7_4.8x6.4mm_P1.60mm (at 0 4.2) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
   (fp_line (start -1.35 -3.2) (end -2.35 -2.2) (layer F.Fab) (width 0.1))
@@ -39,7 +39,7 @@
   (pad 7 smd rect (at 0.05 -2.8) (size 0.6 0.9) (layers F.Cu F.Paste F.Mask))
   (pad 5 smd rect (at 2.4 1.5) (size 1.7 1.8) (layers F.Cu F.Paste F.Mask))
   (pad 6 smd rect (at 2.4 -1.5) (size 1.7 1.8) (layers F.Cu F.Paste F.Mask))
-  (model ${KISYS3DMOD}/Sensor_Current.3dshapes/Allegro_PSOF-7_4.8x6.4mm_Pitch1.60mm.wrl
+  (model ${KISYS3DMOD}/Sensor_Current.3dshapes/Allegro_PSOF-7_4.8x6.4mm_P1.60mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/Sensor_Current.pretty/Allegro_QFN-12-10-1EP_3x3mm_P0.5mm.kicad_mod
+++ b/Sensor_Current.pretty/Allegro_QFN-12-10-1EP_3x3mm_P0.5mm.kicad_mod
@@ -1,11 +1,11 @@
-(module Allegro_QFN-12-10-1EP_3x3mm_Pitch0.5mm (layer F.Cu) (tedit 5A04B3D1)
+(module Allegro_QFN-12-10-1EP_3x3mm_P0.5mm (layer F.Cu) (tedit 5AE4B66E)
   (descr "Allegro Microsystems 12-Lead (10-Lead Populated) Quad Flat Pack, 3x3mm Body, 0.5mm Pitch (http://www.allegromicro.com/~/media/Files/Datasheets/ACS711-Datasheet.ashx)")
   (tags "Allegro QFN 0.5")
   (attr smd)
   (fp_text reference REF** (at 0 -2.8) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (fp_text value Allegro_QFN-12-10-1EP_3x3mm_Pitch0.5mm (at 0 2.8) (layer F.Fab)
+  (fp_text value Allegro_QFN-12-10-1EP_3x3mm_P0.5mm (at 0 2.8) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
   (fp_text user %R (at 0 0) (layer F.Fab)
@@ -43,7 +43,7 @@
   (pad 2 smd rect (at -1.32 0.5) (size 1.07 0.8) (layers F.Cu F.Paste F.Mask))
   (pad 2 smd rect (at -0.685 0.4) (size 0.2 0.6) (layers F.Cu F.Paste F.Mask))
   (pad 2 smd rect (at -0.785 0.7 45) (size 0.2828 0.2828) (layers F.Cu F.Paste F.Mask))
-  (model ${KISYS3DMOD}/Sensor_Current.3dshapes/Allegro_QFN-12-10-1EP_3x3mm_Pitch0.5mm.wrl
+  (model ${KISYS3DMOD}/Sensor_Current.3dshapes/Allegro_QFN-12-10-1EP_3x3mm_P0.5mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/Sensor_Current.pretty/Allegro_QSOP-24_3.9x8.7mm_P0.635mm.kicad_mod
+++ b/Sensor_Current.pretty/Allegro_QSOP-24_3.9x8.7mm_P0.635mm.kicad_mod
@@ -1,11 +1,11 @@
-(module Allegro_QSOP-24_3.9x8.7mm_Pitch0.635mm (layer F.Cu) (tedit 5A04B22B)
+(module Allegro_QSOP-24_3.9x8.7mm_P0.635mm (layer F.Cu) (tedit 5AE4B5E3)
   (descr "Allegro Microsystems 24-Lead Plastic Shrink Small Outline Narrow Body Body [QSOP] (http://www.allegromicro.com/~/media/Files/Datasheets/ACS726-Datasheet.ashx?la=en)")
   (tags "Allegro QSOP 0.635")
   (attr smd)
   (fp_text reference REF** (at 0 -5.25) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (fp_text value Allegro_QSOP-24_3.9x8.7mm_Pitch0.635mm (at 0 5.3) (layer F.Fab)
+  (fp_text value Allegro_QSOP-24_3.9x8.7mm_P0.635mm (at 0 5.3) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
   (fp_text user %R (at 0 0) (layer F.Fab)
@@ -51,7 +51,7 @@
   (pad 22 smd rect (at 2.5 -2.2225) (size 2.3 0.4) (layers F.Cu F.Paste F.Mask))
   (pad 23 smd rect (at 2.5 -2.8575) (size 2.3 0.4) (layers F.Cu F.Paste F.Mask))
   (pad 24 smd rect (at 2.5 -3.4925) (size 2.3 0.4) (layers F.Cu F.Paste F.Mask))
-  (model ${KISYS3DMOD}/Package_SO.3dshapes/QSOP-24_3.9x8.7mm_Pitch0.635mm.wrl
+  (model ${KISYS3DMOD}/Package_SO.3dshapes/QSOP-24_3.9x8.7mm_P0.635mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))


### PR DESCRIPTION
These footprint where not renamed but their corresponding symbols had their footprint fields updated to the new naming convention.