### PR TITLE
Add chamfer to edge pads fo LGA 14 2.5x3mm

### DIFF
--- a/Package_LGA.pretty/LGA-14_3x2.5mm_P0.5mm_LayoutBorder3x4y.kicad_mod
+++ b/Package_LGA.pretty/LGA-14_3x2.5mm_P0.5mm_LayoutBorder3x4y.kicad_mod
@@ -1,4 +1,4 @@
-(module LGA-14_3x2.5mm_P0.5mm_LayoutBorder3x4y (layer F.Cu) (tedit 5AE4FD82)
+(module LGA-14_3x2.5mm_P0.5mm_LayoutBorder3x4y (layer F.Cu) (tedit 5AFC1041)
   (descr "LGA, 14 Pin (http://www.st.com/resource/en/datasheet/lsm6ds3.pdf), generated with kicad-footprint-generator ipc_lga_layoutBorder_generator.py")
   (tags "LGA LGA")
   (attr smd)
@@ -10,10 +10,10 @@
   )
   (fp_line (start 0.96 -1.36) (end 1.61 -1.36) (layer F.SilkS) (width 0.12))
   (fp_line (start 1.61 -1.36) (end 1.61 -1.21) (layer F.SilkS) (width 0.12))
-  (fp_line (start 0.96 1.36) (end 1.61 1.36) (layer F.SilkS) (width 0.12))
-  (fp_line (start 1.61 1.36) (end 1.61 1.21) (layer F.SilkS) (width 0.12))
   (fp_line (start -0.96 1.36) (end -1.61 1.36) (layer F.SilkS) (width 0.12))
   (fp_line (start -1.61 1.36) (end -1.61 1.21) (layer F.SilkS) (width 0.12))
+  (fp_line (start 0.96 1.36) (end 1.61 1.36) (layer F.SilkS) (width 0.12))
+  (fp_line (start 1.61 1.36) (end 1.61 1.21) (layer F.SilkS) (width 0.12))
   (fp_line (start -0.75 -1.25) (end 1.5 -1.25) (layer F.Fab) (width 0.1))
   (fp_line (start 1.5 -1.25) (end 1.5 1.25) (layer F.Fab) (width 0.1))
   (fp_line (start 1.5 1.25) (end -1.5 1.25) (layer F.Fab) (width 0.1))
@@ -23,20 +23,68 @@
   (fp_line (start -1.75 1.5) (end 1.75 1.5) (layer F.CrtYd) (width 0.05))
   (fp_line (start 1.75 1.5) (end 1.75 -1.5) (layer F.CrtYd) (width 0.05))
   (fp_line (start 1.75 -1.5) (end -1.75 -1.5) (layer F.CrtYd) (width 0.05))
-  (pad 1 smd rect (at -1.1375 -0.75) (size 0.675 0.4) (layers F.Cu F.Mask F.Paste))
+  (pad 1 smd custom (at -1.1375 -0.75) (size 0.4 0.4) (layers F.Cu F.Mask F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.3375 -0.2) (xy 0.0875 -0.2) (xy 0.3375 0.05) (xy 0.3375 0.2)
+         (xy -0.3375 0.2)) (width 0))
+    ))
   (pad 2 smd rect (at -1.1375 -0.25) (size 0.675 0.4) (layers F.Cu F.Mask F.Paste))
   (pad 3 smd rect (at -1.1375 0.25) (size 0.675 0.4) (layers F.Cu F.Mask F.Paste))
-  (pad 4 smd rect (at -1.1375 0.75) (size 0.675 0.4) (layers F.Cu F.Mask F.Paste))
-  (pad 5 smd rect (at -0.5 0.8875) (size 0.4 0.675) (layers F.Cu F.Mask F.Paste))
+  (pad 4 smd custom (at -1.1375 0.75) (size 0.4 0.4) (layers F.Cu F.Mask F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.3375 -0.2) (xy 0.3375 -0.2) (xy 0.3375 -0.05) (xy 0.0875 0.2)
+         (xy -0.3375 0.2)) (width 0))
+    ))
+  (pad 5 smd custom (at -0.5 0.8875) (size 0.4 0.4) (layers F.Cu F.Mask F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.2 -0.0875) (xy 0.05 -0.3375) (xy 0.2 -0.3375) (xy 0.2 0.3375)
+         (xy -0.2 0.3375)) (width 0))
+    ))
   (pad 6 smd rect (at 0 0.8875) (size 0.4 0.675) (layers F.Cu F.Mask F.Paste))
-  (pad 7 smd rect (at 0.5 0.8875) (size 0.4 0.675) (layers F.Cu F.Mask F.Paste))
-  (pad 8 smd rect (at 1.1375 0.75) (size 0.675 0.4) (layers F.Cu F.Mask F.Paste))
+  (pad 7 smd custom (at 0.5 0.8875) (size 0.4 0.4) (layers F.Cu F.Mask F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.2 -0.3375) (xy -0.05 -0.3375) (xy 0.2 -0.0875) (xy 0.2 0.3375)
+         (xy -0.2 0.3375)) (width 0))
+    ))
+  (pad 8 smd custom (at 1.1375 0.75) (size 0.4 0.4) (layers F.Cu F.Mask F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.3375 -0.2) (xy 0.3375 -0.2) (xy 0.3375 0.2) (xy -0.0875 0.2)
+         (xy -0.3375 -0.05)) (width 0))
+    ))
   (pad 9 smd rect (at 1.1375 0.25) (size 0.675 0.4) (layers F.Cu F.Mask F.Paste))
   (pad 10 smd rect (at 1.1375 -0.25) (size 0.675 0.4) (layers F.Cu F.Mask F.Paste))
-  (pad 11 smd rect (at 1.1375 -0.75) (size 0.675 0.4) (layers F.Cu F.Mask F.Paste))
-  (pad 12 smd rect (at 0.5 -0.8875) (size 0.4 0.675) (layers F.Cu F.Mask F.Paste))
+  (pad 11 smd custom (at 1.1375 -0.75) (size 0.4 0.4) (layers F.Cu F.Mask F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.3375 0.05) (xy -0.0875 -0.2) (xy 0.3375 -0.2) (xy 0.3375 0.2)
+         (xy -0.3375 0.2)) (width 0))
+    ))
+  (pad 12 smd custom (at 0.5 -0.8875) (size 0.4 0.4) (layers F.Cu F.Mask F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.2 -0.3375) (xy 0.2 -0.3375) (xy 0.2 0.0875) (xy -0.05 0.3375)
+         (xy -0.2 0.3375)) (width 0))
+    ))
   (pad 13 smd rect (at 0 -0.8875) (size 0.4 0.675) (layers F.Cu F.Mask F.Paste))
-  (pad 14 smd rect (at -0.5 -0.8875) (size 0.4 0.675) (layers F.Cu F.Mask F.Paste))
+  (pad 14 smd custom (at -0.5 -0.8875) (size 0.4 0.4) (layers F.Cu F.Mask F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.2 -0.3375) (xy 0.2 -0.3375) (xy 0.2 0.3375) (xy 0.05 0.3375)
+         (xy -0.2 0.0875)) (width 0))
+    ))
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 0.75 0.75) (thickness 0.11)))
   )


### PR DESCRIPTION
This allows for a larger pad to pad clearance between the corner
pads. But with the downside that this fp is now incompatible
with kicad 4.

![screenshot from 2018-05-16 13-05-00](https://user-images.githubusercontent.com/18327350/40113784-e016b128-590a-11e8-9cd8-e08148c77004.png)
