### PR TITLE
move Mini-Circuits CDxxx footprints to Package_SO

### DIFF
--- a/Package_SO.pretty/Mini-Circuits_CD541_H2.08mm.kicad_mod
+++ b/Package_SO.pretty/Mini-Circuits_CD541_H2.08mm.kicad_mod
@@ -1,11 +1,11 @@
-(module Transformer_Mini-Circuits_CD541_H2.08mm (layer F.Cu) (tedit 5A365E23)
+(module Mini-Circuits_CD541_H2.08mm (layer F.Cu) (tedit 5A365E23)
   (descr https://ww2.minicircuits.com/case_style/CD541.pdf)
   (tags "RF Transformer")
   (attr smd)
   (fp_text reference REF** (at 0 -4.826) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (fp_text value Transformer_Mini-Circuits_CD541_H2.08mm (at 0 5.08) (layer F.Fab)
+  (fp_text value Mini-Circuits_CD541_H2.08mm (at 0 5.08) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
   (fp_line (start 2.794 -3.937) (end 2.794 3.937) (layer F.Fab) (width 0.1))
@@ -33,7 +33,7 @@
   (pad 4 smd rect (at 2.54 2.54) (size 2.54 1.65) (layers F.Cu F.Paste F.Mask))
   (pad 5 smd rect (at 2.54 0) (size 2.54 1.65) (layers F.Cu F.Paste F.Mask))
   (pad 6 smd rect (at 2.54 -2.54) (size 2.54 1.65) (layers F.Cu F.Paste F.Mask))
-  (model ${KISYS3DMOD}/Transformer_SMD.3dshapes/Transformer_Mini-Circuits_CD541_H2.08mm.wrl
+  (model ${KISYS3DMOD}/Package_SO.3dshapes/Mini-Circuits_CD541_H2.08mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/Package_SO.pretty/Mini-Circuits_CD542_H2.84mm.kicad_mod
+++ b/Package_SO.pretty/Mini-Circuits_CD542_H2.84mm.kicad_mod
@@ -1,11 +1,11 @@
-(module Transformer_Mini-Circuits_CD542_H2.84mm (layer F.Cu) (tedit 5A365E23)
+(module Mini-Circuits_CD542_H2.84mm (layer F.Cu) (tedit 5A365E23)
   (descr https://ww2.minicircuits.com/case_style/CD542.pdf)
   (tags "RF Transformer")
   (attr smd)
   (fp_text reference REF** (at 0 -4.826) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (fp_text value Transformer_Mini-Circuits_CD542_H2.84mm (at 0 5.08) (layer F.Fab)
+  (fp_text value Mini-Circuits_CD542_H2.84mm (at 0 5.08) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
   (fp_line (start 2.794 -3.937) (end 2.794 3.937) (layer F.Fab) (width 0.1))
@@ -33,7 +33,7 @@
   (pad 4 smd rect (at 2.54 2.54) (size 2.54 1.65) (layers F.Cu F.Paste F.Mask))
   (pad 5 smd rect (at 2.54 0) (size 2.54 1.65) (layers F.Cu F.Paste F.Mask))
   (pad 6 smd rect (at 2.54 -2.54) (size 2.54 1.65) (layers F.Cu F.Paste F.Mask))
-  (model ${KISYS3DMOD}/Transformer_SMD.3dshapes/Transformer_Mini-Circuits_CD542_H2.84mm.wrl
+  (model ${KISYS3DMOD}/Package_SO.3dshapes/Mini-Circuits_CD542_H2.84mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/Package_SO.pretty/Mini-Circuits_CD636_H4.11mm.kicad_mod
+++ b/Package_SO.pretty/Mini-Circuits_CD636_H4.11mm.kicad_mod
@@ -1,11 +1,11 @@
-(module Transformer_Mini-Circuits_CD637_H5.23mm (layer F.Cu) (tedit 5A365E23)
-  (descr https://ww2.minicircuits.com/case_style/CD637.pdf)
+(module Mini-Circuits_CD636_H4.11mm (layer F.Cu) (tedit 5A365E23)
+  (descr https://ww2.minicircuits.com/case_style/CD636.pdf)
   (tags "RF Transformer")
   (attr smd)
   (fp_text reference REF** (at 0 -4.826) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (fp_text value Transformer_Mini-Circuits_CD637_H5.23mm (at 0 5.08) (layer F.Fab)
+  (fp_text value Mini-Circuits_CD636_H4.11mm (at 0 5.08) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
   (fp_line (start 2.794 -3.937) (end 2.794 3.937) (layer F.Fab) (width 0.1))
@@ -33,7 +33,7 @@
   (pad 4 smd rect (at 2.54 2.54) (size 2.54 1.65) (layers F.Cu F.Paste F.Mask))
   (pad 5 smd rect (at 2.54 0) (size 2.54 1.65) (layers F.Cu F.Paste F.Mask))
   (pad 6 smd rect (at 2.54 -2.54) (size 2.54 1.65) (layers F.Cu F.Paste F.Mask))
-  (model ${KISYS3DMOD}/Transformer_SMD.3dshapes/Transformer_Mini-Circuits_CD637_H5.23mm.wrl
+  (model ${KISYS3DMOD}/Package_SO.3dshapes/Mini-Circuits_CD636_H4.11mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/Package_SO.pretty/Mini-Circuits_CD637_H5.23mm.kicad_mod
+++ b/Package_SO.pretty/Mini-Circuits_CD637_H5.23mm.kicad_mod
@@ -1,11 +1,11 @@
-(module Transformer_Mini-Circuits_CD636_H4.11mm (layer F.Cu) (tedit 5A365E23)
-  (descr https://ww2.minicircuits.com/case_style/CD636.pdf)
+(module Mini-Circuits_CD637_H5.23mm (layer F.Cu) (tedit 5A365E23)
+  (descr https://ww2.minicircuits.com/case_style/CD637.pdf)
   (tags "RF Transformer")
   (attr smd)
   (fp_text reference REF** (at 0 -4.826) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (fp_text value Transformer_Mini-Circuits_CD636_H4.11mm (at 0 5.08) (layer F.Fab)
+  (fp_text value Mini-Circuits_CD637_H5.23mm (at 0 5.08) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
   (fp_line (start 2.794 -3.937) (end 2.794 3.937) (layer F.Fab) (width 0.1))
@@ -33,7 +33,7 @@
   (pad 4 smd rect (at 2.54 2.54) (size 2.54 1.65) (layers F.Cu F.Paste F.Mask))
   (pad 5 smd rect (at 2.54 0) (size 2.54 1.65) (layers F.Cu F.Paste F.Mask))
   (pad 6 smd rect (at 2.54 -2.54) (size 2.54 1.65) (layers F.Cu F.Paste F.Mask))
-  (model ${KISYS3DMOD}/Transformer_SMD.3dshapes/Transformer_Mini-Circuits_CD636_H4.11mm.wrl
+  (model ${KISYS3DMOD}/Package_SO.3dshapes/Mini-Circuits_CD637_H5.23mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))


### PR DESCRIPTION
they are not only used for transformers, but are a rather generic footprint used by the manufacturer (example is [this](https://www.minicircuits.com/WebStore/dashboard.html?model=ADP-2-1%2B) power splitter. From Wikipedias description of the different packages I assumed them to be part of the SO category.

No changes to the footprints.

------------

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the footprint(s) you are contributing
- [ ] An example screenshot image is very helpful 
- [ ] If there are matching symbol or 3D model pull requests, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
