### PR TITLE
Convert some pads of jumpers to polygons instead of combination of normal pads

### DIFF
--- a/Jumper.pretty/SolderJumper-2_P1.3mm_Bridged2Bar_Pad1.0x1.5mm.kicad_mod
+++ b/Jumper.pretty/SolderJumper-2_P1.3mm_Bridged2Bar_Pad1.0x1.5mm.kicad_mod
@@ -1,4 +1,4 @@
-(module SolderJumper-2_P1.3mm_Bridged2Bar_Pad1.0x1.5mm (layer F.Cu) (tedit 5A3EABFC)
+(module SolderJumper-2_P1.3mm_Bridged2Bar_Pad1.0x1.5mm (layer F.Cu) (tedit 5B3911BF)
   (descr "SMD Solder Jumper, 1x1.5mm Pads, 0.3mm gap, bridged with 2 copper strips")
   (tags "solder jumper open")
   (attr virtual)
@@ -16,8 +16,13 @@
   (fp_line (start -1.65 -1.25) (end -1.65 1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 1.65 1.25) (end 1.65 -1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 1.65 1.25) (end -1.65 1.25) (layer F.CrtYd) (width 0.05))
-  (pad 1 smd rect (at 0 -0.4) (size 0.5 0.4) (layers F.Cu F.Mask))
-  (pad 1 smd rect (at 0 0.4) (size 0.5 0.4) (layers F.Cu F.Mask))
+  (pad 1 smd custom (at -0.65 0) (size 1 1.5) (layers F.Cu F.Mask)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_poly (pts
+         (xy 0.4 0.2) (xy 0.9 0.2) (xy 0.9 0.6) (xy 0.4 0.6)) (width 0))
+      (gr_poly (pts
+         (xy 0.4 -0.6) (xy 0.9 -0.6) (xy 0.9 -0.2) (xy 0.4 -0.2)) (width 0))
+    ))
   (pad 2 smd rect (at 0.65 0) (size 1 1.5) (layers F.Cu F.Mask))
-  (pad 1 smd rect (at -0.65 0) (size 1 1.5) (layers F.Cu F.Mask))
 )

--- a/Jumper.pretty/SolderJumper-2_P1.3mm_Bridged2Bar_RoundedPad1.0x1.5mm.kicad_mod
+++ b/Jumper.pretty/SolderJumper-2_P1.3mm_Bridged2Bar_RoundedPad1.0x1.5mm.kicad_mod
@@ -1,4 +1,4 @@
-(module SolderJumper-2_P1.3mm_Bridged2Bar_RoundedPad1.0x1.5mm (layer F.Cu) (tedit 5A3EAE8E)
+(module SolderJumper-2_P1.3mm_Bridged2Bar_RoundedPad1.0x1.5mm (layer F.Cu) (tedit 5B3916F8)
   (descr "SMD Solder Jumper, 1x1.5mm, rounded Pads, 0.3mm gap, bridged with 2 copper strips")
   (tags "solder jumper open")
   (attr virtual)
@@ -20,10 +20,26 @@
   (fp_line (start -1.65 -1.25) (end -1.65 1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 1.65 1.25) (end 1.65 -1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 1.65 1.25) (end -1.65 1.25) (layer F.CrtYd) (width 0.05))
-  (pad 1 smd rect (at 0 -0.4) (size 0.5 0.4) (layers F.Cu F.Mask))
-  (pad 1 smd rect (at 0 0.4) (size 0.5 0.4) (layers F.Cu F.Mask))
-  (pad 2 smd roundrect (at 0.65 0) (size 1 1.5) (layers F.Cu F.Mask)(roundrect_rratio 0.5))
-  (pad 1 smd roundrect (at -0.65 0) (size 1 1.5) (layers F.Cu F.Mask)(roundrect_rratio 0.5))
-  (pad 1 smd rect (at -0.4 0) (size 0.5 1.5) (layers F.Cu F.Mask))
-  (pad 2 smd rect (at 0.4 0) (size 0.5 1.5) (layers F.Cu F.Mask))
+  (pad 1 smd custom (at -0.65 0) (size 1 0.5) (layers F.Cu F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
+      (gr_circle (center 0 -0.25) (end 0.5 -0.25) (width 0))
+      (gr_poly (pts
+         (xy 0.5 0.75) (xy 0.5 -0.75) (xy 0 -0.75) (xy 0 0.75)) (width 0))
+      (gr_poly (pts
+         (xy 0.4 0.2) (xy 0.9 0.2) (xy 0.9 0.6) (xy 0.4 0.6)) (width 0))
+      (gr_poly (pts
+         (xy 0.4 -0.6) (xy 0.9 -0.6) (xy 0.9 -0.2) (xy 0.4 -0.2)) (width 0))
+    ))
+  (pad 2 smd custom (at 0.65 0) (size 1 0.5) (layers F.Cu F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
+      (gr_circle (center 0 -0.25) (end 0.5 -0.25) (width 0))
+      (gr_poly (pts
+         (xy -0.5 0.75) (xy -0.5 -0.75) (xy 0 -0.75) (xy 0 0.75)) (width 0))
+    ))
 )

--- a/Jumper.pretty/SolderJumper-2_P1.3mm_Bridged_Pad1.0x1.5mm.kicad_mod
+++ b/Jumper.pretty/SolderJumper-2_P1.3mm_Bridged_Pad1.0x1.5mm.kicad_mod
@@ -1,4 +1,4 @@
-(module SolderJumper-2_P1.3mm_Bridged_Pad1.0x1.5mm (layer F.Cu) (tedit 5A3EABFC)
+(module SolderJumper-2_P1.3mm_Bridged_Pad1.0x1.5mm (layer F.Cu) (tedit 5B391424)
   (descr "SMD Solder Jumper, 1x1.5mm Pads, 0.3mm gap, bridged with 1 copper strip")
   (tags "solder jumper open")
   (attr virtual)
@@ -16,7 +16,11 @@
   (fp_line (start -1.65 -1.25) (end -1.65 1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 1.65 1.25) (end 1.65 -1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 1.65 1.25) (end -1.65 1.25) (layer F.CrtYd) (width 0.05))
-  (pad 1 smd rect (at 0 0) (size 0.5 0.6) (layers F.Cu F.Mask))
+  (pad 1 smd custom (at -0.65 0) (size 1 1.5) (layers F.Cu F.Mask)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_poly (pts
+         (xy 0.4 -0.3) (xy 0.9 -0.3) (xy 0.9 0.3) (xy 0.4 0.3)) (width 0))
+    ))
   (pad 2 smd rect (at 0.65 0) (size 1 1.5) (layers F.Cu F.Mask))
-  (pad 1 smd rect (at -0.65 0) (size 1 1.5) (layers F.Cu F.Mask))
 )

--- a/Jumper.pretty/SolderJumper-2_P1.3mm_Bridged_RoundedPad1.0x1.5mm.kicad_mod
+++ b/Jumper.pretty/SolderJumper-2_P1.3mm_Bridged_RoundedPad1.0x1.5mm.kicad_mod
@@ -1,4 +1,4 @@
-(module SolderJumper-2_P1.3mm_Bridged_RoundedPad1.0x1.5mm (layer F.Cu) (tedit 5A3EAE8E)
+(module SolderJumper-2_P1.3mm_Bridged_RoundedPad1.0x1.5mm (layer F.Cu) (tedit 5B391ABA)
   (descr "SMD Solder Jumper, 1x1.5mm, rounded Pads, 0.3mm gap, bridged with 1 copper strip")
   (tags "solder jumper open")
   (attr virtual)
@@ -20,9 +20,24 @@
   (fp_line (start -1.65 -1.25) (end -1.65 1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 1.65 1.25) (end 1.65 -1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 1.65 1.25) (end -1.65 1.25) (layer F.CrtYd) (width 0.05))
-  (pad 1 smd rect (at 0 0) (size 0.5 0.6) (layers F.Cu F.Mask))
-  (pad 2 smd roundrect (at 0.65 0) (size 1 1.5) (layers F.Cu F.Mask)(roundrect_rratio 0.5))
-  (pad 1 smd roundrect (at -0.65 0) (size 1 1.5) (layers F.Cu F.Mask)(roundrect_rratio 0.5))
-  (pad 1 smd rect (at -0.4 0) (size 0.5 1.5) (layers F.Cu F.Mask))
-  (pad 2 smd rect (at 0.4 0) (size 0.5 1.5) (layers F.Cu F.Mask))
+  (pad 1 smd custom (at -0.65 0) (size 1 0.5) (layers F.Cu F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
+      (gr_circle (center 0 -0.25) (end 0.5 -0.25) (width 0))
+      (gr_poly (pts
+         (xy 0 -0.75) (xy 0.5 -0.75) (xy 0.5 0.75) (xy 0 0.75)) (width 0))
+      (gr_poly (pts
+         (xy 0.9 -0.3) (xy 0.4 -0.3) (xy 0.4 0.3) (xy 0.9 0.3)) (width 0))
+    ))
+  (pad 2 smd custom (at 0.65 0) (size 1 0.5) (layers F.Cu F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
+      (gr_circle (center 0 -0.25) (end 0.5 -0.25) (width 0))
+      (gr_poly (pts
+         (xy 0 -0.75) (xy -0.5 -0.75) (xy -0.5 0.75) (xy 0 0.75)) (width 0))
+    ))
 )

--- a/Jumper.pretty/SolderJumper-2_P1.3mm_Open_RoundedPad1.0x1.5mm.kicad_mod
+++ b/Jumper.pretty/SolderJumper-2_P1.3mm_Open_RoundedPad1.0x1.5mm.kicad_mod
@@ -1,4 +1,4 @@
-(module SolderJumper-2_P1.3mm_Open_RoundedPad1.0x1.5mm (layer F.Cu) (tedit 5A3EAE8E)
+(module SolderJumper-2_P1.3mm_Open_RoundedPad1.0x1.5mm (layer F.Cu) (tedit 5B391E66)
   (descr "SMD Solder Jumper, 1x1.5mm, rounded Pads, 0.3mm gap, open")
   (tags "solder jumper open")
   (attr virtual)
@@ -20,8 +20,22 @@
   (fp_line (start -1.65 -1.25) (end -1.65 1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 1.65 1.25) (end 1.65 -1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 1.65 1.25) (end -1.65 1.25) (layer F.CrtYd) (width 0.05))
-  (pad 2 smd roundrect (at 0.65 0) (size 1 1.5) (layers F.Cu F.Mask)(roundrect_rratio 0.5))
-  (pad 1 smd roundrect (at -0.65 0) (size 1 1.5) (layers F.Cu F.Mask)(roundrect_rratio 0.5))
-  (pad 1 smd rect (at -0.4 0) (size 0.5 1.5) (layers F.Cu F.Mask))
-  (pad 2 smd rect (at 0.4 0) (size 0.5 1.5) (layers F.Cu F.Mask))
+  (pad 1 smd custom (at -0.65 0) (size 1 0.5) (layers F.Cu F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
+      (gr_circle (center 0 -0.25) (end 0.5 -0.25) (width 0))
+      (gr_poly (pts
+         (xy 0 -0.75) (xy 0.5 -0.75) (xy 0.5 0.75) (xy 0 0.75)) (width 0))
+    ))
+  (pad 2 smd custom (at 0.65 0) (size 1 0.5) (layers F.Cu F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
+      (gr_circle (center 0 -0.25) (end 0.5 -0.25) (width 0))
+      (gr_poly (pts
+         (xy 0 -0.75) (xy -0.5 -0.75) (xy -0.5 0.75) (xy 0 0.75)) (width 0))
+    ))
 )

--- a/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged12_Pad1.0x1.5mm.kicad_mod
+++ b/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged12_Pad1.0x1.5mm.kicad_mod
@@ -1,4 +1,4 @@
-(module SolderJumper-3_P1.3mm_Bridged12_Pad1.0x1.5mm (layer F.Cu) (tedit 5A3F8BB2)
+(module SolderJumper-3_P1.3mm_Bridged12_Pad1.0x1.5mm (layer F.Cu) (tedit 5B3914C4)
   (descr "SMD Solder 3-pad Jumper, 1x1.5mm Pads, 0.3mm gap, pads 1-2 bridged with 1 copper strip")
   (tags "solder jumper open")
   (attr virtual)
@@ -19,8 +19,12 @@
   (fp_line (start -2.3 -1.25) (end -2.3 1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 2.3 1.25) (end 2.3 -1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 2.3 1.25) (end -2.3 1.25) (layer F.CrtYd) (width 0.05))
+  (pad 1 smd custom (at -1.3 0) (size 1 1.5) (layers F.Cu F.Mask)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_poly (pts
+         (xy 0.4 -0.3) (xy 0.9 -0.3) (xy 0.9 0.3) (xy 0.4 0.3)) (width 0))
+    ))
   (pad 3 smd rect (at 1.3 0) (size 1 1.5) (layers F.Cu F.Mask))
   (pad 2 smd rect (at 0 0) (size 1 1.5) (layers F.Cu F.Mask))
-  (pad 1 smd rect (at -1.3 0) (size 1 1.5) (layers F.Cu F.Mask))
-  (pad 1 smd rect (at -0.65 0) (size 0.5 0.6) (layers F.Cu F.Mask))
 )

--- a/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged12_Pad1.0x1.5mm_NumberLabels.kicad_mod
+++ b/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged12_Pad1.0x1.5mm_NumberLabels.kicad_mod
@@ -1,4 +1,4 @@
-(module SolderJumper-3_P1.3mm_Bridged12_Pad1.0x1.5mm_NumberLabels (layer F.Cu) (tedit 5A3F6CCC)
+(module SolderJumper-3_P1.3mm_Bridged12_Pad1.0x1.5mm_NumberLabels (layer F.Cu) (tedit 5B3914E1)
   (descr "SMD Solder Jumper, 1x1.5mm Pads, 0.3mm gap, pads 1-2 bridged with 1 copper strip, labeled with numbers")
   (tags "solder jumper open")
   (attr virtual)
@@ -22,8 +22,12 @@
   (fp_line (start -2.3 -1.25) (end -2.3 1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 2.3 1.25) (end 2.3 -1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 2.3 1.25) (end -2.3 1.25) (layer F.CrtYd) (width 0.05))
+  (pad 1 smd custom (at -1.3 0) (size 1 1.5) (layers F.Cu F.Mask)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_poly (pts
+         (xy 0.4 -0.3) (xy 0.9 -0.3) (xy 0.9 0.3) (xy 0.4 0.3)) (width 0))
+    ))
   (pad 3 smd rect (at 1.3 0) (size 1 1.5) (layers F.Cu F.Mask))
   (pad 2 smd rect (at 0 0) (size 1 1.5) (layers F.Cu F.Mask))
-  (pad 1 smd rect (at -1.3 0) (size 1 1.5) (layers F.Cu F.Mask))
-  (pad 1 smd rect (at -0.65 0) (size 0.5 0.6) (layers F.Cu F.Mask))
 )

--- a/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged12_RoundedPad1.0x1.5mm.kicad_mod
+++ b/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged12_RoundedPad1.0x1.5mm.kicad_mod
@@ -1,4 +1,4 @@
-(module SolderJumper-3_P1.3mm_Bridged12_RoundedPad1.0x1.5mm (layer F.Cu) (tedit 5A3F8C1A)
+(module SolderJumper-3_P1.3mm_Bridged12_RoundedPad1.0x1.5mm (layer F.Cu) (tedit 5B391DE3)
   (descr "SMD Solder 3-pad Jumper, 1x1.5mm rounded Pads, 0.3mm gap, pads 1-2 bridged with 1 copper strip")
   (tags "solder jumper open")
   (attr virtual)
@@ -23,10 +23,25 @@
   (fp_arc (start 1.35 0.3) (end 1.35 1) (angle -90) (layer F.SilkS) (width 0.12))
   (fp_arc (start -1.35 0.3) (end -2.05 0.3) (angle -90) (layer F.SilkS) (width 0.12))
   (fp_arc (start -1.35 -0.3) (end -1.35 -1) (angle -90) (layer F.SilkS) (width 0.12))
-  (pad 1 smd roundrect (at -1.3 0) (size 1 1.5) (layers F.Cu F.Mask)(roundrect_rratio 0.5))
-  (pad 1 smd rect (at -1 0) (size 0.5 1.5) (layers F.Cu F.Mask))
+  (pad 1 smd custom (at -1.3 0) (size 1 0.5) (layers F.Cu F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
+      (gr_circle (center 0 -0.25) (end 0.5 -0.25) (width 0))
+      (gr_poly (pts
+         (xy 0.55 -0.75) (xy 0 -0.75) (xy 0 0.75) (xy 0.55 0.75)) (width 0))
+      (gr_poly (pts
+         (xy 0.4 -0.3) (xy 0.9 -0.3) (xy 0.9 0.3) (xy 0.4 0.3)) (width 0))
+    ))
+  (pad 3 smd custom (at 1.3 0) (size 1 0.5) (layers F.Cu F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
+      (gr_circle (center 0 -0.25) (end 0.5 -0.25) (width 0))
+      (gr_poly (pts
+         (xy -0.55 -0.75) (xy 0 -0.75) (xy 0 0.75) (xy -0.55 0.75)) (width 0))
+    ))
   (pad 2 smd rect (at 0 0) (size 1 1.5) (layers F.Cu F.Mask))
-  (pad 3 smd roundrect (at 1.3 0) (size 1 1.5) (layers F.Cu F.Mask)(roundrect_rratio 0.5))
-  (pad 3 smd rect (at 1 0) (size 0.5 1.5) (layers F.Cu F.Mask))
-  (pad 1 smd rect (at -0.65 0) (size 0.5 0.6) (layers F.Cu F.Mask))
 )

--- a/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged12_RoundedPad1.0x1.5mm_NumberLabels.kicad_mod
+++ b/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged12_RoundedPad1.0x1.5mm_NumberLabels.kicad_mod
@@ -1,4 +1,4 @@
-(module SolderJumper-3_P1.3mm_Bridged12_RoundedPad1.0x1.5mm_NumberLabels (layer F.Cu) (tedit 5A3F6CCC)
+(module SolderJumper-3_P1.3mm_Bridged12_RoundedPad1.0x1.5mm_NumberLabels (layer F.Cu) (tedit 5B391DD7)
   (descr "SMD Solder 3-pad Jumper, 1x1.5mm rounded Pads, 0.3mm gap, pads 1-2 bridged with 1 copper strip, labeled with numbers")
   (tags "solder jumper open")
   (attr virtual)
@@ -26,10 +26,25 @@
   (fp_arc (start 1.35 0.3) (end 1.35 1) (angle -90) (layer F.SilkS) (width 0.12))
   (fp_arc (start -1.35 0.3) (end -2.05 0.3) (angle -90) (layer F.SilkS) (width 0.12))
   (fp_arc (start -1.35 -0.3) (end -1.35 -1) (angle -90) (layer F.SilkS) (width 0.12))
-  (pad 1 smd roundrect (at -1.3 0) (size 1 1.5) (layers F.Cu F.Mask)(roundrect_rratio 0.5))
-  (pad 1 smd rect (at -1 0) (size 0.5 1.5) (layers F.Cu F.Mask))
+  (pad 1 smd custom (at -1.3 0) (size 1 0.5) (layers F.Cu F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
+      (gr_circle (center 0 -0.25) (end 0.5 -0.25) (width 0))
+      (gr_poly (pts
+         (xy 0.55 -0.75) (xy 0 -0.75) (xy 0 0.75) (xy 0.55 0.75)) (width 0))
+      (gr_poly (pts
+         (xy 0.4 -0.3) (xy 0.9 -0.3) (xy 0.9 0.3) (xy 0.4 0.3)) (width 0))
+    ))
+  (pad 3 smd custom (at 1.3 0) (size 1 0.5) (layers F.Cu F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
+      (gr_circle (center 0 -0.25) (end 0.5 -0.25) (width 0))
+      (gr_poly (pts
+         (xy -0.55 -0.75) (xy 0 -0.75) (xy 0 0.75) (xy -0.55 0.75)) (width 0))
+    ))
   (pad 2 smd rect (at 0 0) (size 1 1.5) (layers F.Cu F.Mask))
-  (pad 3 smd roundrect (at 1.3 0) (size 1 1.5) (layers F.Cu F.Mask)(roundrect_rratio 0.5))
-  (pad 3 smd rect (at 1 0) (size 0.5 1.5) (layers F.Cu F.Mask))
-  (pad 1 smd rect (at -0.65 0) (size 0.5 0.6) (layers F.Cu F.Mask))
 )

--- a/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged2Bar12_Pad1.0x1.5mm.kicad_mod
+++ b/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged2Bar12_Pad1.0x1.5mm.kicad_mod
@@ -1,4 +1,4 @@
-(module SolderJumper-3_P1.3mm_Bridged2Bar12_Pad1.0x1.5mm (layer F.Cu) (tedit 5A3F8BB2)
+(module SolderJumper-3_P1.3mm_Bridged2Bar12_Pad1.0x1.5mm (layer F.Cu) (tedit 5B391491)
   (descr "SMD Solder 3-pad Jumper, 1x1.5mm Pads, 0.3mm gap, pads 1-2 Bridged2Bar with 2 copper strip")
   (tags "solder jumper open")
   (attr virtual)
@@ -19,9 +19,14 @@
   (fp_line (start -2.3 -1.25) (end -2.3 1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 2.3 1.25) (end 2.3 -1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 2.3 1.25) (end -2.3 1.25) (layer F.CrtYd) (width 0.05))
+  (pad 1 smd custom (at -1.3 0) (size 1 1.5) (layers F.Cu F.Mask)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_poly (pts
+         (xy 0.4 -0.6) (xy 0.9 -0.6) (xy 0.9 -0.2) (xy 0.4 -0.2)) (width 0))
+      (gr_poly (pts
+         (xy 0.4 0.2) (xy 0.9 0.2) (xy 0.9 0.6) (xy 0.4 0.6)) (width 0))
+    ))
   (pad 3 smd rect (at 1.3 0) (size 1 1.5) (layers F.Cu F.Mask))
   (pad 2 smd rect (at 0 0) (size 1 1.5) (layers F.Cu F.Mask))
-  (pad 1 smd rect (at -1.3 0) (size 1 1.5) (layers F.Cu F.Mask))
-  (pad 1 smd rect (at -0.65 -0.4) (size 0.5 0.4) (layers F.Cu F.Mask))
-  (pad 1 smd rect (at -0.65  0.4) (size 0.5 0.4) (layers F.Cu F.Mask))
 )

--- a/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged2Bar12_Pad1.0x1.5mm_NumberLabels.kicad_mod
+++ b/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged2Bar12_Pad1.0x1.5mm_NumberLabels.kicad_mod
@@ -1,4 +1,4 @@
-(module SolderJumper-3_P1.3mm_Bridged2Bar12_Pad1.0x1.5mm_NumberLabels (layer F.Cu) (tedit 5A3F6CCC)
+(module SolderJumper-3_P1.3mm_Bridged2Bar12_Pad1.0x1.5mm_NumberLabels (layer F.Cu) (tedit 5B39184F)
   (descr "SMD Solder Jumper, 1x1.5mm Pads, 0.3mm gap, pads 1-2 Bridged2Bar with 2 copper strip, labeled with numbers")
   (tags "solder jumper open")
   (attr virtual)
@@ -22,9 +22,14 @@
   (fp_line (start -2.3 -1.25) (end -2.3 1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 2.3 1.25) (end 2.3 -1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 2.3 1.25) (end -2.3 1.25) (layer F.CrtYd) (width 0.05))
+  (pad 1 smd custom (at -1.3 0) (size 1 1.5) (layers F.Cu F.Mask)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_poly (pts
+         (xy 0.4 0.2) (xy 0.9 0.2) (xy 0.9 0.6) (xy 0.4 0.6)) (width 0))
+      (gr_poly (pts
+         (xy 0.4 -0.6) (xy 0.9 -0.6) (xy 0.9 -0.2) (xy 0.4 -0.2)) (width 0))
+    ))
   (pad 3 smd rect (at 1.3 0) (size 1 1.5) (layers F.Cu F.Mask))
   (pad 2 smd rect (at 0 0) (size 1 1.5) (layers F.Cu F.Mask))
-  (pad 1 smd rect (at -1.3 0) (size 1 1.5) (layers F.Cu F.Mask))
-  (pad 1 smd rect (at -0.65 -0.4) (size 0.5 0.4) (layers F.Cu F.Mask))
-  (pad 1 smd rect (at -0.65  0.4) (size 0.5 0.4) (layers F.Cu F.Mask))
 )

--- a/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged2Bar12_RoundedPad1.0x1.5mm.kicad_mod
+++ b/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged2Bar12_RoundedPad1.0x1.5mm.kicad_mod
@@ -1,4 +1,4 @@
-(module SolderJumper-3_P1.3mm_Bridged2Bar12_RoundedPad1.0x1.5mm (layer F.Cu) (tedit 5A3F8C1A)
+(module SolderJumper-3_P1.3mm_Bridged2Bar12_RoundedPad1.0x1.5mm (layer F.Cu) (tedit 5B39197B)
   (descr "SMD Solder 3-pad Jumper, 1x1.5mm rounded Pads, 0.3mm gap, pads 1-2 Bridged2Bar with 2 copper strip")
   (tags "solder jumper open")
   (attr virtual)
@@ -23,11 +23,27 @@
   (fp_arc (start 1.35 0.3) (end 1.35 1) (angle -90) (layer F.SilkS) (width 0.12))
   (fp_arc (start -1.35 0.3) (end -2.05 0.3) (angle -90) (layer F.SilkS) (width 0.12))
   (fp_arc (start -1.35 -0.3) (end -1.35 -1) (angle -90) (layer F.SilkS) (width 0.12))
-  (pad 1 smd roundrect (at -1.3 0) (size 1 1.5) (layers F.Cu F.Mask)(roundrect_rratio 0.5))
-  (pad 1 smd rect (at -1 0) (size 0.5 1.5) (layers F.Cu F.Mask))
+  (pad 1 smd custom (at -1.3 0) (size 1 0.5) (layers F.Cu F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
+      (gr_circle (center 0 -0.25) (end 0.5 -0.25) (width 0))
+      (gr_poly (pts
+         (xy 0.55 -0.75) (xy 0 -0.75) (xy 0 0.75) (xy 0.55 0.75)) (width 0))
+      (gr_poly (pts
+         (xy 0.4 -0.6) (xy 0.9 -0.6) (xy 0.9 -0.2) (xy 0.4 -0.2)) (width 0))
+      (gr_poly (pts
+         (xy 0.4 0.2) (xy 0.9 0.2) (xy 0.9 0.6) (xy 0.4 0.6)) (width 0))
+    ))
+  (pad 3 smd custom (at 1.3 0) (size 1 0.5) (layers F.Cu F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
+      (gr_circle (center 0 -0.25) (end 0.5 -0.25) (width 0))
+      (gr_poly (pts
+         (xy -0.55 -0.75) (xy 0 -0.75) (xy 0 0.75) (xy -0.55 0.75)) (width 0))
+    ))
   (pad 2 smd rect (at 0 0) (size 1 1.5) (layers F.Cu F.Mask))
-  (pad 3 smd roundrect (at 1.3 0) (size 1 1.5) (layers F.Cu F.Mask)(roundrect_rratio 0.5))
-  (pad 3 smd rect (at 1 0) (size 0.5 1.5) (layers F.Cu F.Mask))
-  (pad 1 smd rect (at -0.65 -0.4) (size 0.5 0.4) (layers F.Cu F.Mask))
-  (pad 1 smd rect (at -0.65  0.4) (size 0.5 0.4) (layers F.Cu F.Mask))
 )

--- a/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged2Bar12_RoundedPad1.0x1.5mm_NumberLabels.kicad_mod
+++ b/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged2Bar12_RoundedPad1.0x1.5mm_NumberLabels.kicad_mod
@@ -1,4 +1,4 @@
-(module SolderJumper-3_P1.3mm_Bridged2Bar12_RoundedPad1.0x1.5mm_NumberLabels (layer F.Cu) (tedit 5A3F6CCC)
+(module SolderJumper-3_P1.3mm_Bridged2Bar12_RoundedPad1.0x1.5mm_NumberLabels (layer F.Cu) (tedit 5B391A16)
   (descr "SMD Solder 3-pad Jumper, 1x1.5mm rounded Pads, 0.3mm gap, pads 1-2 Bridged2Bar with 2 copper strip, labeled with numbers")
   (tags "solder jumper open")
   (attr virtual)
@@ -26,11 +26,27 @@
   (fp_arc (start 1.35 0.3) (end 1.35 1) (angle -90) (layer F.SilkS) (width 0.12))
   (fp_arc (start -1.35 0.3) (end -2.05 0.3) (angle -90) (layer F.SilkS) (width 0.12))
   (fp_arc (start -1.35 -0.3) (end -1.35 -1) (angle -90) (layer F.SilkS) (width 0.12))
-  (pad 1 smd roundrect (at -1.3 0) (size 1 1.5) (layers F.Cu F.Mask)(roundrect_rratio 0.5))
-  (pad 1 smd rect (at -1 0) (size 0.5 1.5) (layers F.Cu F.Mask))
+  (pad 1 smd custom (at -1.3 0) (size 1 0.5) (layers F.Cu F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
+      (gr_circle (center 0 -0.25) (end 0.5 -0.25) (width 0))
+      (gr_poly (pts
+         (xy 0.55 -0.75) (xy 0 -0.75) (xy 0 0.75) (xy 0.55 0.75)) (width 0))
+      (gr_poly (pts
+         (xy 0.4 -0.6) (xy 0.9 -0.6) (xy 0.9 -0.2) (xy 0.4 -0.2)) (width 0))
+      (gr_poly (pts
+         (xy 0.4 0.2) (xy 0.9 0.2) (xy 0.9 0.6) (xy 0.4 0.6)) (width 0))
+    ))
+  (pad 3 smd custom (at 1.3 0) (size 1 0.5) (layers F.Cu F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
+      (gr_circle (center 0 -0.25) (end 0.5 -0.25) (width 0))
+      (gr_poly (pts
+         (xy -0.55 -0.75) (xy 0 -0.75) (xy 0 0.75) (xy -0.55 0.75)) (width 0))
+    ))
   (pad 2 smd rect (at 0 0) (size 1 1.5) (layers F.Cu F.Mask))
-  (pad 3 smd roundrect (at 1.3 0) (size 1 1.5) (layers F.Cu F.Mask)(roundrect_rratio 0.5))
-  (pad 3 smd rect (at 1 0) (size 0.5 1.5) (layers F.Cu F.Mask))
-  (pad 1 smd rect (at -0.65 -0.4) (size 0.5 0.4) (layers F.Cu F.Mask))
-  (pad 1 smd rect (at -0.65  0.4) (size 0.5 0.4) (layers F.Cu F.Mask))
 )

--- a/Jumper.pretty/SolderJumper-3_P1.3mm_Open_RoundedPad1.0x1.5mm.kicad_mod
+++ b/Jumper.pretty/SolderJumper-3_P1.3mm_Open_RoundedPad1.0x1.5mm.kicad_mod
@@ -1,4 +1,4 @@
-(module SolderJumper-3_P1.3mm_Open_RoundedPad1.0x1.5mm (layer F.Cu) (tedit 5A3F8C1A)
+(module SolderJumper-3_P1.3mm_Open_RoundedPad1.0x1.5mm (layer F.Cu) (tedit 5B391EB7)
   (descr "SMD Solder 3-pad Jumper, 1x1.5mm rounded Pads, 0.3mm gap, open")
   (tags "solder jumper open")
   (attr virtual)
@@ -23,9 +23,23 @@
   (fp_arc (start 1.35 0.3) (end 1.35 1) (angle -90) (layer F.SilkS) (width 0.12))
   (fp_arc (start -1.35 0.3) (end -2.05 0.3) (angle -90) (layer F.SilkS) (width 0.12))
   (fp_arc (start -1.35 -0.3) (end -1.35 -1) (angle -90) (layer F.SilkS) (width 0.12))
-  (pad 1 smd roundrect (at -1.3 0) (size 1 1.5) (layers F.Cu F.Mask)(roundrect_rratio 0.5))
-  (pad 1 smd rect (at -1 0) (size 0.5 1.5) (layers F.Cu F.Mask))
+  (pad 1 smd custom (at -1.3 0) (size 1 0.5) (layers F.Cu F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
+      (gr_circle (center 0 -0.25) (end 0.5 -0.25) (width 0))
+      (gr_poly (pts
+         (xy 0.55 -0.75) (xy 0 -0.75) (xy 0 0.75) (xy 0.55 0.75)) (width 0))
+    ))
+  (pad 3 smd custom (at 1.3 0) (size 1 0.5) (layers F.Cu F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
+      (gr_circle (center 0 -0.25) (end 0.5 -0.25) (width 0))
+      (gr_poly (pts
+         (xy -0.55 -0.75) (xy 0 -0.75) (xy 0 0.75) (xy -0.55 0.75)) (width 0))
+    ))
   (pad 2 smd rect (at 0 0) (size 1 1.5) (layers F.Cu F.Mask))
-  (pad 3 smd roundrect (at 1.3 0) (size 1 1.5) (layers F.Cu F.Mask)(roundrect_rratio 0.5))
-  (pad 3 smd rect (at 1 0) (size 0.5 1.5) (layers F.Cu F.Mask))
 )

--- a/Jumper.pretty/SolderJumper-3_P1.3mm_Open_RoundedPad1.0x1.5mm_NumberLabels.kicad_mod
+++ b/Jumper.pretty/SolderJumper-3_P1.3mm_Open_RoundedPad1.0x1.5mm_NumberLabels.kicad_mod
@@ -1,4 +1,4 @@
-(module SolderJumper-3_P1.3mm_Open_RoundedPad1.0x1.5mm_NumberLabels (layer F.Cu) (tedit 5A3F6CCC)
+(module SolderJumper-3_P1.3mm_Open_RoundedPad1.0x1.5mm_NumberLabels (layer F.Cu) (tedit 5B391ED1)
   (descr "SMD Solder 3-pad Jumper, 1x1.5mm rounded Pads, 0.3mm gap, open, labeled with numbers")
   (tags "solder jumper open")
   (attr virtual)
@@ -26,9 +26,23 @@
   (fp_arc (start 1.35 0.3) (end 1.35 1) (angle -90) (layer F.SilkS) (width 0.12))
   (fp_arc (start -1.35 0.3) (end -2.05 0.3) (angle -90) (layer F.SilkS) (width 0.12))
   (fp_arc (start -1.35 -0.3) (end -1.35 -1) (angle -90) (layer F.SilkS) (width 0.12))
-  (pad 1 smd roundrect (at -1.3 0) (size 1 1.5) (layers F.Cu F.Mask)(roundrect_rratio 0.5))
-  (pad 1 smd rect (at -1 0) (size 0.5 1.5) (layers F.Cu F.Mask))
+  (pad 1 smd custom (at -1.3 0) (size 1 0.5) (layers F.Cu F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
+      (gr_circle (center 0 -0.25) (end 0.5 -0.25) (width 0))
+      (gr_poly (pts
+         (xy 0.55 -0.75) (xy 0 -0.75) (xy 0 0.75) (xy 0.55 0.75)) (width 0))
+    ))
+  (pad 3 smd custom (at 1.3 0) (size 1 0.5) (layers F.Cu F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
+      (gr_circle (center 0 -0.25) (end 0.5 -0.25) (width 0))
+      (gr_poly (pts
+         (xy -0.55 -0.75) (xy 0 -0.75) (xy 0 0.75) (xy -0.55 0.75)) (width 0))
+    ))
   (pad 2 smd rect (at 0 0) (size 1 1.5) (layers F.Cu F.Mask))
-  (pad 3 smd roundrect (at 1.3 0) (size 1 1.5) (layers F.Cu F.Mask)(roundrect_rratio 0.5))
-  (pad 3 smd rect (at 1 0) (size 0.5 1.5) (layers F.Cu F.Mask))
 )


### PR DESCRIPTION
In KiCad 4 there were no polygon pads which resulted in some overlapping pad constructs. This is no longer required, as well as the old system causes some nasty problems like dupliation of pin numbers and unconnected warning. This PR solves the issue for the jumpers by converting some of the pads to polygon pads:

![kicad_polygon_jumper](https://user-images.githubusercontent.com/1652144/42137585-22278eba-7d6f-11e8-9d5e-763b6a0284bf.png)

------------

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [x] An example screenshot image is very helpful 
- [x] Check the output of the Travis automated check scripts - fix any errors as required
