### PR TITLE
Rename SOT-89-5_Housing -> SOT-89-5

### DIFF
--- a/Package_TO_SOT_SMD.pretty/SOT-89-5.kicad_mod
+++ b/Package_TO_SOT_SMD.pretty/SOT-89-5.kicad_mod
@@ -1,11 +1,11 @@
-(module SOT-89-5_Housing (layer F.Cu) (tedit 5A02FF57)
+(module SOT-89-5 (layer F.Cu) (tedit 5A02FF57)
   (descr "SOT-89-5, Housing,http://www.e-devices.ricoh.co.jp/en/products/product_power/pkg/sot-89-5.pdf")
   (tags "SOT-89-5 Housing ")
   (attr smd)
   (fp_text reference REF** (at -0.275 -3.525) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (fp_text value SOT-89-5_Housing (at -0.275 3.325) (layer F.Fab)
+  (fp_text value SOT-89-5 (at -0.275 3.325) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
   (fp_text user %R (at 0 0 90) (layer F.Fab)
@@ -33,7 +33,7 @@
   (pad 2 smd trapezoid (at -0.775 0 90) (size 1.5 0.75) (layers F.Cu F.Paste F.Mask)
     (rect_delta 0 0.5))
   (pad 2 smd rect (at 0 0 270) (size 2 0.8) (layers F.Cu F.Paste F.Mask))
-  (model ${KISYS3DMOD}/Package_TO_SOT_SMD.3dshapes/SOT-89-5_Housing.wrl
+  (model ${KISYS3DMOD}/Package_TO_SOT_SMD.3dshapes/SOT-89-5.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/Package_TO_SOT_SMD.pretty/SOT-89-5_Handsoldering.kicad_mod
+++ b/Package_TO_SOT_SMD.pretty/SOT-89-5_Handsoldering.kicad_mod
@@ -1,11 +1,11 @@
-(module SOT-89-5_Housing_Handsoldering (layer F.Cu) (tedit 5A0BBCA8)
+(module SOT-89-5_Handsoldering (layer F.Cu) (tedit 5A0BBCA8)
   (descr "SOT89-5, Housing,http://www.e-devices.ricoh.co.jp/en/products/product_power/pkg/sot-89-5.pdf")
   (tags "SOT89-5 Housing ")
   (attr smd)
   (fp_text reference REF** (at -0.28 -3.52) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (fp_text value SOT-89-5_Housing_Handsoldering (at -0.28 3.33) (layer F.Fab)
+  (fp_text value SOT-89-5_Handsoldering (at -0.28 3.33) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
   (fp_text user %R (at 0 0 90) (layer F.Fab)
@@ -31,7 +31,7 @@
   (pad 2 smd rect (at 2.35 0 270) (size 1 2.5) (layers F.Cu F.Paste F.Mask))
   (pad 2 smd trapezoid (at -0.78 0 90) (size 1.5 0.75) (rect_delta 0 0.5 ) (layers F.Cu F.Paste F.Mask))
   (pad 2 smd rect (at 0 0 270) (size 2 0.8) (layers F.Cu F.Paste F.Mask))
-  (model ${KISYS3DMOD}/Package_TO_SOT_SMD.3dshapes/SOT-89-5_Housing_Handsoldering.wrl
+  (model ${KISYS3DMOD}/Package_TO_SOT_SMD.3dshapes/SOT-89-5.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))


### PR DESCRIPTION
There's no good reason to have _Housing in that name.

Only one symbol uses this footprint: https://github.com/KiCad/kicad-symbols/pull/732