### PR TITLE
Add _RoundHole to name (now _CircularHoles)

### DIFF
--- a/Connector_Audio.pretty/Jack_3.5mm_QingPu_WQP-PJ398SM_Vertical_CircularHoles.kicad_mod
+++ b/Connector_Audio.pretty/Jack_3.5mm_QingPu_WQP-PJ398SM_Vertical_CircularHoles.kicad_mod
@@ -1,10 +1,10 @@
-(module Jack_3.5mm_QingPu_WQP-PJ398SM_Vertical_RoundHoles (layer F.Cu) (tedit 5B6EDBBA)
+(module Jack_3.5mm_QingPu_WQP-PJ398SM_Vertical_CircularHoles (layer F.Cu) (tedit 5B6EDBBA)
   (descr "TRS 3.5mm, vertical, Thonkiconn, PCB mount, (http://www.qingpu-electronics.com/en/products/WQP-PJ398SM-362.html)")
   (tags "WQP-PJ398SM TRS 3.5mm mono vertical jack thonkiconn qingpu")
   (fp_text reference REF** (at -4.03 1.08 180) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (fp_text value Jack_3.5mm_QingPu_WQP-PJ398SM_Vertical_RoundHoles (at 0 5 180) (layer F.Fab)
+  (fp_text value Jack_3.5mm_QingPu_WQP-PJ398SM_Vertical_CircularHoles (at 0 5 180) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
   (fp_text user KEEPOUT (at 0 6.48) (layer Cmts.User)
@@ -45,7 +45,7 @@
   (pad 2 thru_hole oval (at 0 3.1 180) (size 2.8 2.35) (drill 1.8) (layers *.Cu *.Mask))
   (pad 1 thru_hole rect (at 0 0 180) (size 2.6 2.15) (drill 1.6) (layers *.Cu *.Mask))
   (pad 3 thru_hole circle (at 0 11.4 180) (size 2.7 2.7) (drill 1.8) (layers *.Cu *.Mask))
-  (model ${KISYS3DMOD}/Connector_Audio.3dshapes/Jack_3.5mm_QingPu_WQP-PJ398SM_Vertical_RoundHoles.wrl
+  (model ${KISYS3DMOD}/Connector_Audio.3dshapes/Jack_3.5mm_QingPu_WQP-PJ398SM_Vertical_CircularHoles.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/Connector_Audio.pretty/Jack_3.5mm_QingPu_WQP-PJ398SM_Vertical_CircularHoles.kicad_mod
+++ b/Connector_Audio.pretty/Jack_3.5mm_QingPu_WQP-PJ398SM_Vertical_CircularHoles.kicad_mod
@@ -45,7 +45,7 @@
   (pad 2 thru_hole oval (at 0 3.1 180) (size 2.8 2.35) (drill 1.8) (layers *.Cu *.Mask))
   (pad 1 thru_hole rect (at 0 0 180) (size 2.6 2.15) (drill 1.6) (layers *.Cu *.Mask))
   (pad 3 thru_hole circle (at 0 11.4 180) (size 2.7 2.7) (drill 1.8) (layers *.Cu *.Mask))
-  (model ${KISYS3DMOD}/Connector_Audio.3dshapes/Jack_3.5mm_QingPu_WQP-PJ398SM_Vertical_CircularHoles.wrl
+  (model ${KISYS3DMOD}/Connector_Audio.3dshapes/Jack_3.5mm_QingPu_WQP-PJ398SM_Vertical.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/Connector_Audio.pretty/Jack_3.5mm_QingPu_WQP-PJ398SM_Vertical_RoundHoles.kicad_mod
+++ b/Connector_Audio.pretty/Jack_3.5mm_QingPu_WQP-PJ398SM_Vertical_RoundHoles.kicad_mod
@@ -1,4 +1,4 @@
-(module Jack_3.5mm_QingPu_WQP-PJ398SM_Vertical (layer F.Cu) (tedit 5B6EDBBA)
+(module Jack_3.5mm_QingPu_WQP-PJ398SM_Vertical_RoundHole (layer F.Cu) (tedit 5B6EDBBA)
   (descr "TRS 3.5mm, vertical, Thonkiconn, PCB mount, (http://www.qingpu-electronics.com/en/products/WQP-PJ398SM-362.html)")
   (tags "WQP-PJ398SM TRS 3.5mm mono vertical jack thonkiconn qingpu")
   (fp_text reference REF** (at -4.03 1.08 180) (layer F.SilkS)

--- a/Connector_Audio.pretty/Jack_3.5mm_QingPu_WQP-PJ398SM_Vertical_RoundHoles.kicad_mod
+++ b/Connector_Audio.pretty/Jack_3.5mm_QingPu_WQP-PJ398SM_Vertical_RoundHoles.kicad_mod
@@ -1,10 +1,10 @@
-(module Jack_3.5mm_QingPu_WQP-PJ398SM_Vertical_RoundHole (layer F.Cu) (tedit 5B6EDBBA)
+(module Jack_3.5mm_QingPu_WQP-PJ398SM_Vertical_RoundHoles (layer F.Cu) (tedit 5B6EDBBA)
   (descr "TRS 3.5mm, vertical, Thonkiconn, PCB mount, (http://www.qingpu-electronics.com/en/products/WQP-PJ398SM-362.html)")
   (tags "WQP-PJ398SM TRS 3.5mm mono vertical jack thonkiconn qingpu")
   (fp_text reference REF** (at -4.03 1.08 180) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (fp_text value Jack_3.5mm_QingPu_WQP-PJ398SM_Vertical (at 0 5 180) (layer F.Fab)
+  (fp_text value Jack_3.5mm_QingPu_WQP-PJ398SM_Vertical_RoundHoles (at 0 5 180) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
   (fp_text user KEEPOUT (at 0 6.48) (layer Cmts.User)
@@ -45,7 +45,7 @@
   (pad 2 thru_hole oval (at 0 3.1 180) (size 2.8 2.35) (drill 1.8) (layers *.Cu *.Mask))
   (pad 1 thru_hole rect (at 0 0 180) (size 2.6 2.15) (drill 1.6) (layers *.Cu *.Mask))
   (pad 3 thru_hole circle (at 0 11.4 180) (size 2.7 2.7) (drill 1.8) (layers *.Cu *.Mask))
-  (model ${KISYS3DMOD}/Connector_Audio.3dshapes/Jack_3.5mm_QingPu_WQP-PJ398SM_Vertical.wrl
+  (model ${KISYS3DMOD}/Connector_Audio.3dshapes/Jack_3.5mm_QingPu_WQP-PJ398SM_Vertical_RoundHoles.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))


### PR DESCRIPTION
regular footprint Jack_3.5mm_QingPu_WQP-PJ398SM_Vertical.kicad_mod with oval holes to follow