### PR TITLE
Top tented version of qfn-56 footprint for cypress

### DIFF
--- a/Package_DFN_QFN.pretty/QFN-56-1EP_8x8mm_P0.5mm_EP4.5x5.2mm_ThermalVias_TopTented.kicad_mod
+++ b/Package_DFN_QFN.pretty/QFN-56-1EP_8x8mm_P0.5mm_EP4.5x5.2mm_ThermalVias_TopTented.kicad_mod
@@ -1,0 +1,470 @@
+(module QFN-56-1EP_8x8mm_P0.5mm_EP4.5x5.2mm_ThermalVias_TopTented (layer F.Cu) (tedit 5B701CEB)
+  (descr "QFN, 56 Pin (http://www.ti.com/lit/an/scea032/scea032.pdf (page 4)), generated with kicad-footprint-generator ipc_dfn_qfn_generator.py")
+  (tags "QFN DFN_QFN")
+  (attr smd)
+  (fp_text reference REF** (at 0 -5.32) (layer F.SilkS)
+    (effects (font (size 1 1) (thickness 0.15)))
+  )
+  (fp_text value QFN-56-1EP_8x8mm_P0.5mm_EP4.5x5.2mm_ThermalVias_TopTented (at 0 5.32) (layer F.Fab)
+    (effects (font (size 1 1) (thickness 0.15)))
+  )
+  (fp_line (start 3.635 -4.11) (end 4.11 -4.11) (layer F.SilkS) (width 0.12))
+  (fp_line (start 4.11 -4.11) (end 4.11 -3.635) (layer F.SilkS) (width 0.12))
+  (fp_line (start -3.635 4.11) (end -4.11 4.11) (layer F.SilkS) (width 0.12))
+  (fp_line (start -4.11 4.11) (end -4.11 3.635) (layer F.SilkS) (width 0.12))
+  (fp_line (start 3.635 4.11) (end 4.11 4.11) (layer F.SilkS) (width 0.12))
+  (fp_line (start 4.11 4.11) (end 4.11 3.635) (layer F.SilkS) (width 0.12))
+  (fp_line (start -3.635 -4.11) (end -4.11 -4.11) (layer F.SilkS) (width 0.12))
+  (fp_line (start -3 -4) (end 4 -4) (layer F.Fab) (width 0.1))
+  (fp_line (start 4 -4) (end 4 4) (layer F.Fab) (width 0.1))
+  (fp_line (start 4 4) (end -4 4) (layer F.Fab) (width 0.1))
+  (fp_line (start -4 4) (end -4 -3) (layer F.Fab) (width 0.1))
+  (fp_line (start -4 -3) (end -3 -4) (layer F.Fab) (width 0.1))
+  (fp_line (start -4.62 -4.62) (end -4.62 4.62) (layer F.CrtYd) (width 0.05))
+  (fp_line (start -4.62 4.62) (end 4.62 4.62) (layer F.CrtYd) (width 0.05))
+  (fp_line (start 4.62 4.62) (end 4.62 -4.62) (layer F.CrtYd) (width 0.05))
+  (fp_line (start 4.62 -4.62) (end -4.62 -4.62) (layer F.CrtYd) (width 0.05))
+  (fp_text user %R (at 0 0) (layer F.Fab)
+    (effects (font (size 1 1) (thickness 0.15)))
+  )
+  (pad 57 smd roundrect (at 0 0) (size 4.5 5.2) (layers F.Cu) (roundrect_rratio 0.05599999999999999))
+  (pad 57 thru_hole circle (at -2 -2.35) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
+  (pad 57 thru_hole circle (at -1 -2.35) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
+  (pad 57 thru_hole circle (at 0 -2.35) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
+  (pad 57 thru_hole circle (at 1 -2.35) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
+  (pad 57 thru_hole circle (at 2 -2.35) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
+  (pad 57 thru_hole circle (at -2 -1.175) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
+  (pad 57 thru_hole circle (at -1 -1.175) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
+  (pad 57 thru_hole circle (at 0 -1.175) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
+  (pad 57 thru_hole circle (at 1 -1.175) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
+  (pad 57 thru_hole circle (at 2 -1.175) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
+  (pad 57 thru_hole circle (at -2 0) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
+  (pad 57 thru_hole circle (at -1 0) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
+  (pad 57 thru_hole circle (at 0 0) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
+  (pad 57 thru_hole circle (at 1 0) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
+  (pad 57 thru_hole circle (at 2 0) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
+  (pad 57 thru_hole circle (at -2 1.175) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
+  (pad 57 thru_hole circle (at -1 1.175) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
+  (pad 57 thru_hole circle (at 0 1.175) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
+  (pad 57 thru_hole circle (at 1 1.175) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
+  (pad 57 thru_hole circle (at 2 1.175) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
+  (pad 57 thru_hole circle (at -2 2.35) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
+  (pad 57 thru_hole circle (at -1 2.35) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
+  (pad 57 thru_hole circle (at 0 2.35) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
+  (pad 57 thru_hole circle (at 1 2.35) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
+  (pad 57 thru_hole circle (at 2 2.35) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
+  (pad 57 smd roundrect (at 0 0) (size 4.5 5.2) (layers B.Cu) (roundrect_rratio 0.055556))
+  (pad 1 smd roundrect (at -3.9375 -3.25) (size 0.875 0.25) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 2 smd roundrect (at -3.9375 -2.75) (size 0.875 0.25) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 3 smd roundrect (at -3.9375 -2.25) (size 0.875 0.25) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 4 smd roundrect (at -3.9375 -1.75) (size 0.875 0.25) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 5 smd roundrect (at -3.9375 -1.25) (size 0.875 0.25) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 6 smd roundrect (at -3.9375 -0.75) (size 0.875 0.25) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 7 smd roundrect (at -3.9375 -0.25) (size 0.875 0.25) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 8 smd roundrect (at -3.9375 0.25) (size 0.875 0.25) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 9 smd roundrect (at -3.9375 0.75) (size 0.875 0.25) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 10 smd roundrect (at -3.9375 1.25) (size 0.875 0.25) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 11 smd roundrect (at -3.9375 1.75) (size 0.875 0.25) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 12 smd roundrect (at -3.9375 2.25) (size 0.875 0.25) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 13 smd roundrect (at -3.9375 2.75) (size 0.875 0.25) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 14 smd roundrect (at -3.9375 3.25) (size 0.875 0.25) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 15 smd roundrect (at -3.25 3.9375) (size 0.25 0.875) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 16 smd roundrect (at -2.75 3.9375) (size 0.25 0.875) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 17 smd roundrect (at -2.25 3.9375) (size 0.25 0.875) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 18 smd roundrect (at -1.75 3.9375) (size 0.25 0.875) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 19 smd roundrect (at -1.25 3.9375) (size 0.25 0.875) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 20 smd roundrect (at -0.75 3.9375) (size 0.25 0.875) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 21 smd roundrect (at -0.25 3.9375) (size 0.25 0.875) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 22 smd roundrect (at 0.25 3.9375) (size 0.25 0.875) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 23 smd roundrect (at 0.75 3.9375) (size 0.25 0.875) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 24 smd roundrect (at 1.25 3.9375) (size 0.25 0.875) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 25 smd roundrect (at 1.75 3.9375) (size 0.25 0.875) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 26 smd roundrect (at 2.25 3.9375) (size 0.25 0.875) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 27 smd roundrect (at 2.75 3.9375) (size 0.25 0.875) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 28 smd roundrect (at 3.25 3.9375) (size 0.25 0.875) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 29 smd roundrect (at 3.9375 3.25) (size 0.875 0.25) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 30 smd roundrect (at 3.9375 2.75) (size 0.875 0.25) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 31 smd roundrect (at 3.9375 2.25) (size 0.875 0.25) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 32 smd roundrect (at 3.9375 1.75) (size 0.875 0.25) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 33 smd roundrect (at 3.9375 1.25) (size 0.875 0.25) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 34 smd roundrect (at 3.9375 0.75) (size 0.875 0.25) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 35 smd roundrect (at 3.9375 0.25) (size 0.875 0.25) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 36 smd roundrect (at 3.9375 -0.25) (size 0.875 0.25) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 37 smd roundrect (at 3.9375 -0.75) (size 0.875 0.25) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 38 smd roundrect (at 3.9375 -1.25) (size 0.875 0.25) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 39 smd roundrect (at 3.9375 -1.75) (size 0.875 0.25) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 40 smd roundrect (at 3.9375 -2.25) (size 0.875 0.25) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 41 smd roundrect (at 3.9375 -2.75) (size 0.875 0.25) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 42 smd roundrect (at 3.9375 -3.25) (size 0.875 0.25) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 43 smd roundrect (at 3.25 -3.9375) (size 0.25 0.875) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 44 smd roundrect (at 2.75 -3.9375) (size 0.25 0.875) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 45 smd roundrect (at 2.25 -3.9375) (size 0.25 0.875) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 46 smd roundrect (at 1.75 -3.9375) (size 0.25 0.875) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 47 smd roundrect (at 1.25 -3.9375) (size 0.25 0.875) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 48 smd roundrect (at 0.75 -3.9375) (size 0.25 0.875) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 49 smd roundrect (at 0.25 -3.9375) (size 0.25 0.875) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 50 smd roundrect (at -0.25 -3.9375) (size 0.25 0.875) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 51 smd roundrect (at -0.75 -3.9375) (size 0.25 0.875) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 52 smd roundrect (at -1.25 -3.9375) (size 0.25 0.875) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 53 smd roundrect (at -1.75 -3.9375) (size 0.25 0.875) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 54 smd roundrect (at -2.25 -3.9375) (size 0.25 0.875) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 55 smd roundrect (at -2.75 -3.9375) (size 0.25 0.875) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad 56 smd roundrect (at -3.25 -3.9375) (size 0.25 0.875) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
+  (pad "" smd custom (at -1.5 -1.7625) (size 0.776286 0.776286) (layers F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.435 -0.3575) (xy -0.29 -0.5025) (xy 0.29 -0.5025) (xy 0.435 -0.3575) (xy 0.435 0.3575)
+         (xy 0.29 0.5025) (xy -0.29 0.5025) (xy -0.435 0.3575)) (width 0))
+    ))
+  (pad "" smd custom (at -0.5 -1.7625) (size 0.776286 0.776286) (layers F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.435 -0.3575) (xy -0.29 -0.5025) (xy 0.29 -0.5025) (xy 0.435 -0.3575) (xy 0.435 0.3575)
+         (xy 0.29 0.5025) (xy -0.29 0.5025) (xy -0.435 0.3575)) (width 0))
+    ))
+  (pad "" smd custom (at 0.5 -1.7625) (size 0.776286 0.776286) (layers F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.435 -0.3575) (xy -0.29 -0.5025) (xy 0.29 -0.5025) (xy 0.435 -0.3575) (xy 0.435 0.3575)
+         (xy 0.29 0.5025) (xy -0.29 0.5025) (xy -0.435 0.3575)) (width 0))
+    ))
+  (pad "" smd custom (at 1.5 -1.7625) (size 0.776286 0.776286) (layers F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.435 -0.3575) (xy -0.29 -0.5025) (xy 0.29 -0.5025) (xy 0.435 -0.3575) (xy 0.435 0.3575)
+         (xy 0.29 0.5025) (xy -0.29 0.5025) (xy -0.435 0.3575)) (width 0))
+    ))
+  (pad "" smd custom (at -0.5 -0.5875) (size 0.776286 0.776286) (layers F.Mask)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.3 -0.5875) (xy -0.3 -0.5025) (xy 0.3 -0.5025) (xy 0.3 -0.5875)) (width 0))
+      (gr_poly (pts
+         (xy -0.435 -0.3675) (xy -0.3 -0.5025) (xy 0.3 -0.5025) (xy 0.435 -0.3675) (xy 0.435 0.3675)
+         (xy 0.3 0.5025) (xy -0.3 0.5025) (xy -0.435 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy -0.3 0.5025) (xy -0.3 0.5875) (xy 0.3 0.5875) (xy 0.3 0.5025)) (width 0))
+      (gr_poly (pts
+         (xy -0.435 -0.3675) (xy -0.5 -0.3675) (xy -0.5 0.3675) (xy -0.435 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy 0.5 -0.3675) (xy 0.435 -0.3675) (xy 0.435 0.3675) (xy 0.5 0.3675)) (width 0))
+    ))
+  (pad "" smd custom (at 1.5 -0.5875) (size 0.776286 0.776286) (layers F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.435 -0.3575) (xy -0.29 -0.5025) (xy 0.29 -0.5025) (xy 0.435 -0.3575) (xy 0.435 0.3575)
+         (xy 0.29 0.5025) (xy -0.29 0.5025) (xy -0.435 0.3575)) (width 0))
+    ))
+  (pad "" smd custom (at 0.5 -0.5875) (size 0.776286 0.776286) (layers F.Mask)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.3 -0.5875) (xy -0.3 -0.5025) (xy 0.3 -0.5025) (xy 0.3 -0.5875)) (width 0))
+      (gr_poly (pts
+         (xy -0.435 -0.3675) (xy -0.3 -0.5025) (xy 0.3 -0.5025) (xy 0.435 -0.3675) (xy 0.435 0.3675)
+         (xy 0.3 0.5025) (xy -0.3 0.5025) (xy -0.435 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy -0.3 0.5025) (xy -0.3 0.5875) (xy 0.3 0.5875) (xy 0.3 0.5025)) (width 0))
+      (gr_poly (pts
+         (xy -0.435 -0.3675) (xy -0.5 -0.3675) (xy -0.5 0.3675) (xy -0.435 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy 0.5 -0.3675) (xy 0.435 -0.3675) (xy 0.435 0.3675) (xy 0.5 0.3675)) (width 0))
+    ))
+  (pad "" smd custom (at 0.5 -0.5875) (size 0.776286 0.776286) (layers F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.435 -0.3575) (xy -0.29 -0.5025) (xy 0.29 -0.5025) (xy 0.435 -0.3575) (xy 0.435 0.3575)
+         (xy 0.29 0.5025) (xy -0.29 0.5025) (xy -0.435 0.3575)) (width 0))
+    ))
+  (pad "" smd custom (at -1.5 -0.5875) (size 0.776286 0.776286) (layers F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.435 -0.3575) (xy -0.29 -0.5025) (xy 0.29 -0.5025) (xy 0.435 -0.3575) (xy 0.435 0.3575)
+         (xy 0.29 0.5025) (xy -0.29 0.5025) (xy -0.435 0.3575)) (width 0))
+    ))
+  (pad "" smd custom (at -0.5 -0.5875) (size 0.776286 0.776286) (layers F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.435 -0.3575) (xy -0.29 -0.5025) (xy 0.29 -0.5025) (xy 0.435 -0.3575) (xy 0.435 0.3575)
+         (xy 0.29 0.5025) (xy -0.29 0.5025) (xy -0.435 0.3575)) (width 0))
+    ))
+  (pad "" smd custom (at -0.5 0.5875) (size 0.776286 0.776286) (layers F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.435 -0.3575) (xy -0.29 -0.5025) (xy 0.29 -0.5025) (xy 0.435 -0.3575) (xy 0.435 0.3575)
+         (xy 0.29 0.5025) (xy -0.29 0.5025) (xy -0.435 0.3575)) (width 0))
+    ))
+  (pad "" smd custom (at -1.5 0.5875) (size 0.776286 0.776286) (layers F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.435 -0.3575) (xy -0.29 -0.5025) (xy 0.29 -0.5025) (xy 0.435 -0.3575) (xy 0.435 0.3575)
+         (xy 0.29 0.5025) (xy -0.29 0.5025) (xy -0.435 0.3575)) (width 0))
+    ))
+  (pad "" smd custom (at 0.5 0.5875) (size 0.776286 0.776286) (layers F.Mask)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.3 -0.5875) (xy -0.3 -0.5025) (xy 0.3 -0.5025) (xy 0.3 -0.5875)) (width 0))
+      (gr_poly (pts
+         (xy -0.435 -0.3675) (xy -0.3 -0.5025) (xy 0.3 -0.5025) (xy 0.435 -0.3675) (xy 0.435 0.3675)
+         (xy 0.3 0.5025) (xy -0.3 0.5025) (xy -0.435 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy -0.3 0.5025) (xy -0.3 0.5875) (xy 0.3 0.5875) (xy 0.3 0.5025)) (width 0))
+      (gr_poly (pts
+         (xy -0.435 -0.3675) (xy -0.5 -0.3675) (xy -0.5 0.3675) (xy -0.435 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy 0.5 -0.3675) (xy 0.435 -0.3675) (xy 0.435 0.3675) (xy 0.5 0.3675)) (width 0))
+    ))
+  (pad "" smd custom (at -0.5 0.5875) (size 0.776286 0.776286) (layers F.Mask)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.3 -0.5875) (xy -0.3 -0.5025) (xy 0.3 -0.5025) (xy 0.3 -0.5875)) (width 0))
+      (gr_poly (pts
+         (xy -0.435 -0.3675) (xy -0.3 -0.5025) (xy 0.3 -0.5025) (xy 0.435 -0.3675) (xy 0.435 0.3675)
+         (xy 0.3 0.5025) (xy -0.3 0.5025) (xy -0.435 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy -0.3 0.5025) (xy -0.3 0.5875) (xy 0.3 0.5875) (xy 0.3 0.5025)) (width 0))
+      (gr_poly (pts
+         (xy -0.435 -0.3675) (xy -0.5 -0.3675) (xy -0.5 0.3675) (xy -0.435 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy 0.5 -0.3675) (xy 0.435 -0.3675) (xy 0.435 0.3675) (xy 0.5 0.3675)) (width 0))
+    ))
+  (pad "" smd custom (at 0.5 0.5875) (size 0.776286 0.776286) (layers F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.435 -0.3575) (xy -0.29 -0.5025) (xy 0.29 -0.5025) (xy 0.435 -0.3575) (xy 0.435 0.3575)
+         (xy 0.29 0.5025) (xy -0.29 0.5025) (xy -0.435 0.3575)) (width 0))
+    ))
+  (pad "" smd custom (at 1.5 0.5875) (size 0.776286 0.776286) (layers F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.435 -0.3575) (xy -0.29 -0.5025) (xy 0.29 -0.5025) (xy 0.435 -0.3575) (xy 0.435 0.3575)
+         (xy 0.29 0.5025) (xy -0.29 0.5025) (xy -0.435 0.3575)) (width 0))
+    ))
+  (pad "" smd custom (at -0.5 1.7625) (size 0.776286 0.776286) (layers F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.435 -0.3575) (xy -0.29 -0.5025) (xy 0.29 -0.5025) (xy 0.435 -0.3575) (xy 0.435 0.3575)
+         (xy 0.29 0.5025) (xy -0.29 0.5025) (xy -0.435 0.3575)) (width 0))
+    ))
+  (pad "" smd custom (at -1.5 1.7625) (size 0.776286 0.776286) (layers F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.435 -0.3575) (xy -0.29 -0.5025) (xy 0.29 -0.5025) (xy 0.435 -0.3575) (xy 0.435 0.3575)
+         (xy 0.29 0.5025) (xy -0.29 0.5025) (xy -0.435 0.3575)) (width 0))
+    ))
+  (pad "" smd custom (at 0.5 1.7625) (size 0.776286 0.776286) (layers F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.435 -0.3575) (xy -0.29 -0.5025) (xy 0.29 -0.5025) (xy 0.435 -0.3575) (xy 0.435 0.3575)
+         (xy 0.29 0.5025) (xy -0.29 0.5025) (xy -0.435 0.3575)) (width 0))
+    ))
+  (pad "" smd custom (at 1.5 1.7625) (size 0.776286 0.776286) (layers F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.435 -0.3575) (xy -0.29 -0.5025) (xy 0.29 -0.5025) (xy 0.435 -0.3575) (xy 0.435 0.3575)
+         (xy 0.29 0.5025) (xy -0.29 0.5025) (xy -0.435 0.3575)) (width 0))
+    ))
+  (pad "" smd custom (at 1.5 -0.5875) (size 0.776286 0.776286) (layers F.Mask)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy 0.75 -0.3675) (xy 0.435 -0.3675) (xy 0.435 0.3675) (xy 0.75 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy -0.435 -0.3675) (xy -0.5 -0.3675) (xy -0.5 0.3675) (xy -0.435 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy -0.435 -0.3675) (xy -0.3 -0.5025) (xy 0.3 -0.5025) (xy 0.435 -0.3675) (xy 0.435 0.3675)
+         (xy 0.3 0.5025) (xy -0.3 0.5025) (xy -0.435 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy -0.3 0.5025) (xy -0.3 0.5875) (xy 0.3 0.5875) (xy 0.3 0.5025)) (width 0))
+      (gr_poly (pts
+         (xy -0.3 -0.5875) (xy -0.3 -0.5025) (xy 0.3 -0.5025) (xy 0.3 -0.5875)) (width 0))
+    ))
+  (pad "" smd custom (at 1.5 -1.7625) (size 0.776286 0.776286) (layers F.Mask)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.435 -0.3675) (xy -0.5 -0.3675) (xy -0.5 0.3675) (xy -0.435 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy 0.75 -0.3675) (xy 0.435 -0.3675) (xy 0.435 0.3675) (xy 0.75 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy -0.435 -0.3675) (xy -0.3 -0.5025) (xy 0.3 -0.5025) (xy 0.435 -0.3675) (xy 0.435 0.3675)
+         (xy 0.3 0.5025) (xy -0.3 0.5025) (xy -0.435 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy -0.3 0.5025) (xy -0.3 0.5875) (xy 0.3 0.5875) (xy 0.3 0.5025)) (width 0))
+      (gr_poly (pts
+         (xy -0.3 -0.837549) (xy -0.3 -0.5025) (xy 0.3 -0.5025) (xy 0.3 -0.837549)) (width 0))
+    ))
+  (pad "" smd custom (at 0.5 -1.7625) (size 0.776286 0.776286) (layers F.Mask)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy 0.5 -0.3675) (xy 0.435 -0.3675) (xy 0.435 0.3675) (xy 0.5 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy -0.435 -0.3675) (xy -0.3 -0.5025) (xy 0.3 -0.5025) (xy 0.435 -0.3675) (xy 0.435 0.3675)
+         (xy 0.3 0.5025) (xy -0.3 0.5025) (xy -0.435 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy -0.435 -0.3675) (xy -0.5 -0.3675) (xy -0.5 0.3675) (xy -0.435 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy -0.3 0.5025) (xy -0.3 0.5875) (xy 0.3 0.5875) (xy 0.3 0.5025)) (width 0))
+      (gr_poly (pts
+         (xy -0.3 -0.837549) (xy -0.3 -0.5025) (xy 0.3 -0.5025) (xy 0.3 -0.837549)) (width 0))
+    ))
+  (pad "" smd custom (at -1.5 -1.7625) (size 0.776286 0.776286) (layers F.Mask)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.3 -0.837549) (xy -0.3 -0.5025) (xy 0.3 -0.5025) (xy 0.3 -0.837549)) (width 0))
+      (gr_poly (pts
+         (xy -0.3 0.5025) (xy -0.3 0.5875) (xy 0.3 0.5875) (xy 0.3 0.5025)) (width 0))
+      (gr_poly (pts
+         (xy -0.435 -0.3675) (xy -0.3 -0.5025) (xy 0.3 -0.5025) (xy 0.435 -0.3675) (xy 0.435 0.3675)
+         (xy 0.3 0.5025) (xy -0.3 0.5025) (xy -0.435 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy -0.435 -0.3675) (xy -0.75 -0.3675) (xy -0.75 0.3675) (xy -0.435 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy 0.5 -0.3675) (xy 0.435 -0.3675) (xy 0.435 0.3675) (xy 0.5 0.3675)) (width 0))
+    ))
+  (pad "" smd custom (at -1.5 -0.5875) (size 0.776286 0.776286) (layers F.Mask)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.435 -0.3675) (xy -0.75 -0.3675) (xy -0.75 0.3675) (xy -0.435 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy -0.3 -0.5875) (xy -0.3 -0.5025) (xy 0.3 -0.5025) (xy 0.3 -0.5875)) (width 0))
+      (gr_poly (pts
+         (xy -0.435 -0.3675) (xy -0.3 -0.5025) (xy 0.3 -0.5025) (xy 0.435 -0.3675) (xy 0.435 0.3675)
+         (xy 0.3 0.5025) (xy -0.3 0.5025) (xy -0.435 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy -0.3 0.5025) (xy -0.3 0.5875) (xy 0.3 0.5875) (xy 0.3 0.5025)) (width 0))
+      (gr_poly (pts
+         (xy 0.5 -0.3675) (xy 0.435 -0.3675) (xy 0.435 0.3675) (xy 0.5 0.3675)) (width 0))
+    ))
+  (pad "" smd custom (at -1.5 1.7625) (size 0.776286 0.776286) (layers F.Mask)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.3 0.5025) (xy -0.3 0.837549) (xy 0.3 0.837549) (xy 0.3 0.5025)) (width 0))
+      (gr_poly (pts
+         (xy 0.5 -0.3675) (xy 0.435 -0.3675) (xy 0.435 0.3675) (xy 0.5 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy -0.435 -0.3675) (xy -0.75 -0.3675) (xy -0.75 0.3675) (xy -0.435 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy -0.435 -0.3675) (xy -0.3 -0.5025) (xy 0.3 -0.5025) (xy 0.435 -0.3675) (xy 0.435 0.3675)
+         (xy 0.3 0.5025) (xy -0.3 0.5025) (xy -0.435 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy -0.3 -0.5875) (xy -0.3 -0.5025) (xy 0.3 -0.5025) (xy 0.3 -0.5875)) (width 0))
+    ))
+  (pad "" smd custom (at -0.5 1.7625) (size 0.776286 0.776286) (layers F.Mask)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.3 -0.5875) (xy -0.3 -0.5025) (xy 0.3 -0.5025) (xy 0.3 -0.5875)) (width 0))
+      (gr_poly (pts
+         (xy -0.3 0.5025) (xy -0.3 0.837549) (xy 0.3 0.837549) (xy 0.3 0.5025)) (width 0))
+      (gr_poly (pts
+         (xy -0.435 -0.3675) (xy -0.3 -0.5025) (xy 0.3 -0.5025) (xy 0.435 -0.3675) (xy 0.435 0.3675)
+         (xy 0.3 0.5025) (xy -0.3 0.5025) (xy -0.435 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy 0.5 -0.3675) (xy 0.435 -0.3675) (xy 0.435 0.3675) (xy 0.5 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy -0.435 -0.3675) (xy -0.5 -0.3675) (xy -0.5 0.3675) (xy -0.435 0.3675)) (width 0))
+    ))
+  (pad "" smd custom (at 1.5 1.7625) (size 0.776286 0.776286) (layers F.Mask)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.3 -0.5875) (xy -0.3 -0.5025) (xy 0.3 -0.5025) (xy 0.3 -0.5875)) (width 0))
+      (gr_poly (pts
+         (xy 0.75 -0.3675) (xy 0.435 -0.3675) (xy 0.435 0.3675) (xy 0.75 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy -0.435 -0.3675) (xy -0.3 -0.5025) (xy 0.3 -0.5025) (xy 0.435 -0.3675) (xy 0.435 0.3675)
+         (xy 0.3 0.5025) (xy -0.3 0.5025) (xy -0.435 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy -0.3 0.5025) (xy -0.3 0.837549) (xy 0.3 0.837549) (xy 0.3 0.5025)) (width 0))
+      (gr_poly (pts
+         (xy -0.435 -0.3675) (xy -0.5 -0.3675) (xy -0.5 0.3675) (xy -0.435 0.3675)) (width 0))
+    ))
+  (pad "" smd custom (at 1.5 0.5875) (size 0.776286 0.776286) (layers F.Mask)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy 0.75 -0.3675) (xy 0.435 -0.3675) (xy 0.435 0.3675) (xy 0.75 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy -0.435 -0.3675) (xy -0.5 -0.3675) (xy -0.5 0.3675) (xy -0.435 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy -0.435 -0.3675) (xy -0.3 -0.5025) (xy 0.3 -0.5025) (xy 0.435 -0.3675) (xy 0.435 0.3675)
+         (xy 0.3 0.5025) (xy -0.3 0.5025) (xy -0.435 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy -0.3 0.5025) (xy -0.3 0.5875) (xy 0.3 0.5875) (xy 0.3 0.5025)) (width 0))
+      (gr_poly (pts
+         (xy -0.3 -0.5875) (xy -0.3 -0.5025) (xy 0.3 -0.5025) (xy 0.3 -0.5875)) (width 0))
+    ))
+  (pad "" smd custom (at 0.5 1.7625) (size 0.776286 0.776286) (layers F.Mask)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.3 -0.5875) (xy -0.3 -0.5025) (xy 0.3 -0.5025) (xy 0.3 -0.5875)) (width 0))
+      (gr_poly (pts
+         (xy -0.3 0.5025) (xy -0.3 0.837549) (xy 0.3 0.837549) (xy 0.3 0.5025)) (width 0))
+      (gr_poly (pts
+         (xy -0.435 -0.3675) (xy -0.3 -0.5025) (xy 0.3 -0.5025) (xy 0.435 -0.3675) (xy 0.435 0.3675)
+         (xy 0.3 0.5025) (xy -0.3 0.5025) (xy -0.435 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy 0.5 -0.3675) (xy 0.435 -0.3675) (xy 0.435 0.3675) (xy 0.5 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy -0.435 -0.3675) (xy -0.5 -0.3675) (xy -0.5 0.3675) (xy -0.435 0.3675)) (width 0))
+    ))
+  (pad "" smd custom (at -1.5 0.5875) (size 0.776286 0.776286) (layers F.Mask)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.435 -0.3675) (xy -0.75 -0.3675) (xy -0.75 0.3675) (xy -0.435 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy -0.3 -0.5875) (xy -0.3 -0.5025) (xy 0.3 -0.5025) (xy 0.3 -0.5875)) (width 0))
+      (gr_poly (pts
+         (xy -0.435 -0.3675) (xy -0.3 -0.5025) (xy 0.3 -0.5025) (xy 0.435 -0.3675) (xy 0.435 0.3675)
+         (xy 0.3 0.5025) (xy -0.3 0.5025) (xy -0.435 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy -0.3 0.5025) (xy -0.3 0.5875) (xy 0.3 0.5875) (xy 0.3 0.5025)) (width 0))
+      (gr_poly (pts
+         (xy 0.5 -0.3675) (xy 0.435 -0.3675) (xy 0.435 0.3675) (xy 0.5 0.3675)) (width 0))
+    ))
+  (pad "" smd custom (at -0.5 -1.7625) (size 0.776286 0.776286) (layers F.Mask)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy 0.5 -0.3675) (xy 0.435 -0.3675) (xy 0.435 0.3675) (xy 0.5 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy -0.435 -0.3675) (xy -0.3 -0.5025) (xy 0.3 -0.5025) (xy 0.435 -0.3675) (xy 0.435 0.3675)
+         (xy 0.3 0.5025) (xy -0.3 0.5025) (xy -0.435 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy -0.435 -0.3675) (xy -0.5 -0.3675) (xy -0.5 0.3675) (xy -0.435 0.3675)) (width 0))
+      (gr_poly (pts
+         (xy -0.3 0.5025) (xy -0.3 0.5875) (xy 0.3 0.5875) (xy 0.3 0.5025)) (width 0))
+      (gr_poly (pts
+         (xy -0.3 -0.837549) (xy -0.3 -0.5025) (xy 0.3 -0.5025) (xy 0.3 -0.837549)) (width 0))
+    ))
+  (model ${KISYS3DMOD}/Package_DFN_QFN.3dshapes/QFN-56-1EP_8x8mm_P0.5mm_EP4.5x5.2mm.wrl
+    (at (xyz 0 0 0))
+    (scale (xyz 1 1 1))
+    (rotate (xyz 0 0 0))
+  )
+)

--- a/Package_DFN_QFN.pretty/QFN-56-1EP_8x8mm_P0.5mm_EP4.5x5.2mm_ThermalVias_TopTented.kicad_mod
+++ b/Package_DFN_QFN.pretty/QFN-56-1EP_8x8mm_P0.5mm_EP4.5x5.2mm_ThermalVias_TopTented.kicad_mod
@@ -1,5 +1,5 @@
 (module QFN-56-1EP_8x8mm_P0.5mm_EP4.5x5.2mm_ThermalVias_TopTented (layer F.Cu) (tedit 5B701CEB)
-  (descr "QFN, 56 Pin (http://www.ti.com/lit/an/scea032/scea032.pdf (page 4)), generated with kicad-footprint-generator ipc_dfn_qfn_generator.py")
+  (descr "QFN, 56 Pin top tented version (manually modified). For information see: http://www.cypress.com/file/138911/download")
   (tags "QFN DFN_QFN")
   (attr smd)
   (fp_text reference REF** (at 0 -5.32) (layer F.SilkS)


### PR DESCRIPTION
Cypress suggests the use of top tented vias in the exposed pad.
Hand modified the current generic footprint such that it uses this
tenting as an example of how it can be achieved.

Followup for https://github.com/KiCad/kicad-footprints/pull/810
This one showcases how i would make a top tented footprint. (If i am motivated i will add this to the script.)
It is an alternative to the version added in https://github.com/KiCad/kicad-footprints/pull/582 (Using custom pads instead of relying on overlapping graphical lines.)

![screenshot from 2018-08-12 13-43-12](https://user-images.githubusercontent.com/18327350/44004698-f93d436e-9e66-11e8-9218-b9e445a9a242.png)
