### PR TITLE
QFN-28_4x4 use rounded chamfered pad

### DIFF
--- a/Package_DFN_QFN.pretty/QFN-28_4x4mm_P0.5mm.kicad_mod
+++ b/Package_DFN_QFN.pretty/QFN-28_4x4mm_P0.5mm.kicad_mod
@@ -1,4 +1,4 @@
-(module QFN-28_4x4mm_P0.5mm (layer F.Cu) (tedit 5B5A5435)
+(module QFN-28_4x4mm_P0.5mm (layer F.Cu) (tedit 5B776923)
   (descr "QFN, 28 Pin (http://www.st.com/resource/en/datasheet/stm32f031k6.pdf (Page 280)), generated with kicad-footprint-generator ipc_dfn_qfn_generator.py")
   (tags "QFN DFN_QFN")
   (attr smd)
@@ -28,8 +28,8 @@
     (options (clearance outline) (anchor circle))
     (primitives
       (gr_poly (pts
-         (xy -0.3625 -0.125) (xy 0.2125 -0.125) (xy 0.3625 0.025) (xy 0.3625 0.125)
-         (xy -0.3625 0.125)) (width 0))
+         (xy -0.3125 -0.075) (xy 0.1625 -0.075) (xy 0.3125 0.075) (xy 0.3125 0.075)
+         (xy -0.3125 0.075)) (width 0.1))
     ))
   (pad 2 smd roundrect (at -1.9375 -1) (size 0.825 0.25) (layers F.Cu F.Mask F.Paste) (roundrect_rratio 0.25))
   (pad 3 smd roundrect (at -1.9375 -0.5) (size 0.825 0.25) (layers F.Cu F.Mask F.Paste) (roundrect_rratio 0.25))
@@ -40,15 +40,15 @@
     (options (clearance outline) (anchor circle))
     (primitives
       (gr_poly (pts
-         (xy -0.3625 -0.125) (xy 0.3625 -0.125) (xy 0.3625 -0.025) (xy 0.2125 0.125)
-         (xy -0.3625 0.125)) (width 0))
+         (xy -0.3125 -0.075) (xy 0.3125 -0.075) (xy 0.3125 -0.075) (xy 0.1625 0.075)
+         (xy -0.3125 0.075)) (width 0.1))
     ))
   (pad 8 smd custom (at -1.5 1.9875) (size 0.143934 0.143934) (layers F.Cu F.Mask F.Paste)
     (options (clearance outline) (anchor circle))
     (primitives
       (gr_poly (pts
-         (xy -0.125 -0.2125) (xy 0.025 -0.3625) (xy 0.125 -0.3625) (xy 0.125 0.3625)
-         (xy -0.125 0.3625)) (width 0))
+         (xy -0.075 -0.1625) (xy 0.075 -0.3125) (xy 0.075 -0.3125) (xy 0.075 0.3125)
+         (xy -0.075 0.3125)) (width 0.1))
     ))
   (pad 9 smd roundrect (at -1 1.9375) (size 0.25 0.825) (layers F.Cu F.Mask F.Paste) (roundrect_rratio 0.25))
   (pad 10 smd roundrect (at -0.5 1.9375) (size 0.25 0.825) (layers F.Cu F.Mask F.Paste) (roundrect_rratio 0.25))
@@ -59,15 +59,15 @@
     (options (clearance outline) (anchor circle))
     (primitives
       (gr_poly (pts
-         (xy -0.125 -0.3625) (xy -0.025 -0.3625) (xy 0.125 -0.2125) (xy 0.125 0.3625)
-         (xy -0.125 0.3625)) (width 0))
+         (xy -0.075 -0.3125) (xy -0.075 -0.3125) (xy 0.075 -0.1625) (xy 0.075 0.3125)
+         (xy -0.075 0.3125)) (width 0.1))
     ))
   (pad 15 smd custom (at 1.9875 1.5) (size 0.143934 0.143934) (layers F.Cu F.Mask F.Paste)
     (options (clearance outline) (anchor circle))
     (primitives
       (gr_poly (pts
-         (xy -0.3625 -0.125) (xy 0.3625 -0.125) (xy 0.3625 0.125) (xy -0.2125 0.125)
-         (xy -0.3625 -0.025)) (width 0))
+         (xy -0.3125 -0.075) (xy 0.3125 -0.075) (xy 0.3125 0.075) (xy -0.1625 0.075)
+         (xy -0.3125 -0.075)) (width 0.1))
     ))
   (pad 16 smd roundrect (at 1.9375 1) (size 0.825 0.25) (layers F.Cu F.Mask F.Paste) (roundrect_rratio 0.25))
   (pad 17 smd roundrect (at 1.9375 0.5) (size 0.825 0.25) (layers F.Cu F.Mask F.Paste) (roundrect_rratio 0.25))
@@ -78,15 +78,15 @@
     (options (clearance outline) (anchor circle))
     (primitives
       (gr_poly (pts
-         (xy -0.3625 0.025) (xy -0.2125 -0.125) (xy 0.3625 -0.125) (xy 0.3625 0.125)
-         (xy -0.3625 0.125)) (width 0))
+         (xy -0.3125 0.075) (xy -0.1625 -0.075) (xy 0.3125 -0.075) (xy 0.3125 0.075)
+         (xy -0.3125 0.075)) (width 0.1))
     ))
   (pad 22 smd custom (at 1.5 -1.9875) (size 0.143934 0.143934) (layers F.Cu F.Mask F.Paste)
     (options (clearance outline) (anchor circle))
     (primitives
       (gr_poly (pts
-         (xy -0.125 -0.3625) (xy 0.125 -0.3625) (xy 0.125 0.2125) (xy -0.025 0.3625)
-         (xy -0.125 0.3625)) (width 0))
+         (xy -0.075 -0.3125) (xy 0.075 -0.3125) (xy 0.075 0.1625) (xy -0.075 0.3125)
+         (xy -0.075 0.3125)) (width 0.1))
     ))
   (pad 23 smd roundrect (at 1 -1.9375) (size 0.25 0.825) (layers F.Cu F.Mask F.Paste) (roundrect_rratio 0.25))
   (pad 24 smd roundrect (at 0.5 -1.9375) (size 0.25 0.825) (layers F.Cu F.Mask F.Paste) (roundrect_rratio 0.25))
@@ -97,8 +97,8 @@
     (options (clearance outline) (anchor circle))
     (primitives
       (gr_poly (pts
-         (xy -0.125 -0.3625) (xy 0.125 -0.3625) (xy 0.125 0.3625) (xy 0.025 0.3625)
-         (xy -0.125 0.2125)) (width 0))
+         (xy -0.075 -0.3125) (xy 0.075 -0.3125) (xy 0.075 0.3125) (xy 0.075 0.3125)
+         (xy -0.075 0.1625)) (width 0.1))
     ))
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))


### PR DESCRIPTION
The script is now capable of creating rounded chamfered pads (special
case of polygon pads that can be easily converted to have rounded
corners)

Screenshot of the affected pads
![screenshot from 2018-08-18 03-01-20](https://user-images.githubusercontent.com/18327350/44294180-4f5a2480-a293-11e8-9c75-22cf15d10035.png)