### PR TITLE
Fixing microSD_HC_Hirose_DM3D-SF footprint offset according to 3D model

### DIFF
--- a/Connector_Card.pretty/microSD_HC_Hirose_DM3D-SF.kicad_mod
+++ b/Connector_Card.pretty/microSD_HC_Hirose_DM3D-SF.kicad_mod
@@ -1,4 +1,4 @@
-(module microSD_HC_Hirose_DM3D-SF (layer F.Cu) (tedit 5A1DBFB5)
+(module microSD_HC_Hirose_DM3D-SF (layer F.Cu) (tedit 5B82D16A)
   (descr "Micro SD, SMD, right-angle, push-pull (https://media.digikey.com/PDF/Data%20Sheets/Hirose%20PDFs/DM3D-SF.pdf)")
   (tags "Micro SD")
   (attr smd)
@@ -94,7 +94,7 @@
   (pad 11 smd rect (at 5.625 5.225) (size 1.5 1.5) (layers F.Cu F.Paste F.Mask))
   (pad 10 smd rect (at 5.575 -5.45) (size 1 1.55) (layers F.Cu F.Paste F.Mask))
   (model ${KISYS3DMOD}/Connector_Card.3dshapes/microSD_HC_Hirose_DM3D-SF.wrl
-    (at (xyz -0.1781496063 -0.1761811024 0))
+    (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))
   )


### PR DESCRIPTION
microSD_HC_Hirose_DM3D-SF footprint offset fixed for matching [3D package](https://github.com/KiCad/kicad-packages3D/pull/376)

------------

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the footprint(s) you are contributing
- [ ] An example screenshot image is very helpful 
- [ ] If there are matching symbol or 3D model pull requests, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
