### PR TITLE
Changed central pad's to custom pad

### DIFF
--- a/Package_DFN_QFN.pretty/Texas_VQFN-RHL-20.kicad_mod
+++ b/Package_DFN_QFN.pretty/Texas_VQFN-RHL-20.kicad_mod
@@ -1,4 +1,4 @@
-(module Texas_VQFN-RHL-20 (layer F.Cu) (tedit 5B73332D)
+(module Texas_VQFN-RHL-20 (layer F.Cu) (tedit 5B833432)
   (descr http://www.ti.com/lit/ds/symlink/bq51050b.pdf)
   (tags RHL0020A)
   (attr smd)
@@ -35,9 +35,6 @@
   (pad "" smd rect (at -0.56 0) (size 0.92 0.85) (layers F.Paste))
   (pad "" smd rect (at 0.56 -1.05) (size 0.92 0.85) (layers F.Paste))
   (pad "" smd rect (at -0.56 -1.05) (size 0.92 0.85) (layers F.Paste))
-  (pad 21 smd rect (at 0 1.725) (size 0.75 0.4) (layers F.Cu F.Mask))
-  (pad 21 smd rect (at 0 -1.725) (size 0.75 0.4) (layers F.Cu F.Mask))
-  (pad 21 smd rect (at 0 0) (size 2.05 3.05) (layers F.Cu F.Mask))
   (pad 21 smd roundrect (at 0.275 2.15) (size 0.2 0.6) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
   (pad 21 smd roundrect (at -0.275 2.15) (size 0.2 0.6) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
   (pad 21 smd roundrect (at 0.275 -2.15) (size 0.2 0.6) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25))
@@ -62,6 +59,15 @@
   (pad 3 smd roundrect (at -1.65 -1.25) (size 0.6 0.24) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.21))
   (pad 2 smd roundrect (at -1.65 -1.75) (size 0.6 0.24) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.21))
   (pad 1 smd roundrect (at -0.75 -2.15) (size 0.24 0.6) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.21))
+  (pad 21 smd custom (at 0 0) (size 1.524 1.524) (layers F.Cu F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_poly (pts
+         (xy 1.025 1.525) (xy 1.025 -1.525) (xy 0.375 -1.525) (xy 0.375 -1.925) (xy -0.375 -1.925)
+         (xy -0.375 -1.525) (xy -1.025 -1.525) (xy -1.025 1.525) (xy -0.375 1.525) (xy -0.375 1.925)
+         (xy 0.375 1.925) (xy 0.375 1.525)) (width 0))
+    ))
   (model ${KISYS3DMOD}/Package_DFN_QFN.3dshapes/Texas_VQFN-RHL-20_ThermalVias.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))

--- a/Package_DFN_QFN.pretty/Texas_VQFN-RHL-20_ThermalVias.kicad_mod
+++ b/Package_DFN_QFN.pretty/Texas_VQFN-RHL-20_ThermalVias.kicad_mod
@@ -1,4 +1,4 @@
-(module Texas_VQFN-RHL-20_ThermalVias (layer F.Cu) (tedit 5B7333A7)
+(module Texas_VQFN-RHL-20_ThermalVias (layer F.Cu) (tedit 5B833463)
   (descr http://www.ti.com/lit/ds/symlink/bq51050b.pdf)
   (tags RHL0020A)
   (attr smd)
@@ -35,9 +35,6 @@
   (pad "" smd rect (at -0.56 0) (size 0.92 0.85) (layers F.Paste))
   (pad "" smd rect (at 0.56 -1.05) (size 0.92 0.85) (layers F.Paste))
   (pad "" smd rect (at -0.56 -1.05) (size 0.92 0.85) (layers F.Paste))
-  (pad 21 smd rect (at 0 1.725) (size 0.75 0.4) (layers F.Cu F.Mask))
-  (pad 21 smd rect (at 0 -1.725) (size 0.75 0.4) (layers F.Cu F.Mask))
-  (pad 21 smd rect (at 0 0) (size 2.05 3.05) (layers F.Cu F.Mask))
   (pad 21 thru_hole circle (at 0 1.275) (size 0.5 0.5) (drill 0.2) (layers *.Cu)
     (zone_connect 2))
   (pad 21 thru_hole circle (at 0 -1.275) (size 0.5 0.5) (drill 0.2) (layers *.Cu)
@@ -78,7 +75,15 @@
   (pad 3 smd roundrect (at -1.65 -1.25) (size 0.6 0.24) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.21))
   (pad 2 smd roundrect (at -1.65 -1.75) (size 0.6 0.24) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.21))
   (pad 1 smd roundrect (at -0.75 -2.15) (size 0.24 0.6) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.21))
-  (pad 21 smd rect (at 0 0) (size 2.05 3.05) (layers B.Cu))
+  (pad 21 smd custom (at 0 0) (size 1.524 1.524) (layers F.Cu F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_poly (pts
+         (xy 1.025 1.525) (xy 1.025 -1.525) (xy 0.375 -1.525) (xy 0.375 -1.925) (xy -0.375 -1.925)
+         (xy -0.375 -1.525) (xy -1.025 -1.525) (xy -1.025 1.525) (xy -0.375 1.525) (xy -0.375 1.925)
+         (xy 0.375 1.925) (xy 0.375 1.525)) (width 0))
+    ))
   (model ${KISYS3DMOD}/Package_DFN_QFN.3dshapes/Texas_VQFN-RHL-20_ThermalVias.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))


### PR DESCRIPTION
Replace central pad's to custom pad, early requested by @poeschlr 

Datasheet: http://www.ti.com/lit/ds/symlink/bq51050b.pdf - page 41
Central custom pad measurements:
![texas](https://user-images.githubusercontent.com/8236353/44634464-54edf380-a992-11e8-853d-e9243f094da0.png)

------------

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [x] Provide a URL to a datasheet for the footprint(s) you are contributing
- [x] An example screenshot image is very helpful 
- [ ] If there are matching symbol or 3D model pull requests, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
