### PR TITLE
Finish #433 add virtual footprint for CR1225 3d model

### DIFF
--- a/Battery.pretty/Battery_CR1225.kicad_mod
+++ b/Battery.pretty/Battery_CR1225.kicad_mod
@@ -1,11 +1,11 @@
-(module Battery_CR1225 (layer F.Cu) (tedit 5B93F27C)
+(module Battery_CR1225 (layer F.Cu) (tedit 5B93F51B)
   (descr "CR1225 battery")
   (tags "battery CR1225 coin cell")
   (attr virtual)
-  (fp_text reference REF** (at 0 0.5) (layer F.SilkS) hide
+  (fp_text reference REF** (at 0 -1) (layer F.SilkS) hide
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (fp_text value Battery_CR1225 (at 0 -0.5) (layer F.Fab)
+  (fp_text value Battery_CR1225 (at 0 0.5) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
   (fp_circle (center 0 0) (end 6.25 0) (layer F.Fab) (width 0.1))

--- a/Battery.pretty/Battery_CR1225.kicad_mod
+++ b/Battery.pretty/Battery_CR1225.kicad_mod
@@ -1,0 +1,17 @@
+(module Battery_CR1225 (layer F.Cu) (tedit 5B93F27C)
+  (descr "CR1225 battery")
+  (tags "battery CR1225 coin cell")
+  (attr virtual)
+  (fp_text reference REF** (at 0 0.5) (layer F.SilkS) hide
+    (effects (font (size 1 1) (thickness 0.15)))
+  )
+  (fp_text value Battery_CR1225 (at 0 -0.5) (layer F.Fab)
+    (effects (font (size 1 1) (thickness 0.15)))
+  )
+  (fp_circle (center 0 0) (end 6.25 0) (layer F.Fab) (width 0.1))
+  (model ${KISYS3DMOD}/Battery.3dshapes/Battery_CR1225.wrl
+    (at (xyz 0 0 0))
+    (scale (xyz 1 1 1))
+    (rotate (xyz 0 0 0))
+  )
+)


### PR DESCRIPTION
This footprint is only to have the 3D model of the battery usable.
![cr1225](https://user-images.githubusercontent.com/5279723/45256170-0b8aa480-b393-11e8-9513-1558e61f1d87.png)


------------

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the footprint(s) you are contributing
- [x] An example screenshot image is very helpful 
- [ ] If there are matching symbol or 3D model pull requests, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
