### PR TITLE
Correct WQP-PJ398SM/Thonkiconn pad names

### DIFF
--- a/Connector_Audio.pretty/Jack_3.5mm_QingPu_WQP-PJ398SM_Vertical_CircularHoles.kicad_mod
+++ b/Connector_Audio.pretty/Jack_3.5mm_QingPu_WQP-PJ398SM_Vertical_CircularHoles.kicad_mod
@@ -1,4 +1,4 @@
-(module Jack_3.5mm_QingPu_WQP-PJ398SM_Vertical_CircularHoles (layer F.Cu) (tedit 5B6EDBBA)
+(module Jack_3.5mm_QingPu_WQP-PJ398SM_Vertical_CircularHoles (layer F.Cu) (tedit 5B95684F)
   (descr "TRS 3.5mm, vertical, Thonkiconn, PCB mount, (http://www.qingpu-electronics.com/en/products/WQP-PJ398SM-362.html)")
   (tags "WQP-PJ398SM TRS 3.5mm mono vertical jack thonkiconn qingpu")
   (fp_text reference REF** (at -4.03 1.08 180) (layer F.SilkS)
@@ -42,9 +42,9 @@
   (fp_line (start 4.5 2.03) (end -4.5 2.03) (layer F.Fab) (width 0.1))
   (fp_circle (center 0 6.48) (end 1.8 6.48) (layer F.Fab) (width 0.1))
   (fp_line (start 0 0) (end 0 2.03) (layer F.Fab) (width 0.1))
-  (pad 2 thru_hole oval (at 0 3.1 180) (size 2.8 2.35) (drill 1.8) (layers *.Cu *.Mask))
-  (pad 1 thru_hole rect (at 0 0 180) (size 2.6 2.15) (drill 1.6) (layers *.Cu *.Mask))
-  (pad 3 thru_hole circle (at 0 11.4 180) (size 2.7 2.7) (drill 1.8) (layers *.Cu *.Mask))
+  (pad TN thru_hole oval (at 0 3.1 180) (size 2.8 2.35) (drill 1.8) (layers *.Cu *.Mask))
+  (pad S thru_hole rect (at 0 0 180) (size 2.6 2.15) (drill 1.6) (layers *.Cu *.Mask))
+  (pad T thru_hole circle (at 0 11.4 180) (size 2.7 2.7) (drill 1.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Connector_Audio.3dshapes/Jack_3.5mm_QingPu_WQP-PJ398SM_Vertical.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))


### PR DESCRIPTION
Match the pad names to the [Connector:AudioJack2_Ground_Switch](https://github.com/KiCad/kicad-symbols/blob/master/Connector.lib#L713) symbol
names.

![thonkiconn-pj398sm](https://user-images.githubusercontent.com/124381/45269823-2546ed00-b462-11e8-86ba-f0d694bb29da.jpg)

(copied from https://www.thonk.co.uk/shop/thonkiconn/ )

------------

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [x] Provide a URL to a datasheet for the footprint(s) you are contributing
- [ ] An example screenshot image is very helpful 
- [x] If there are matching symbol or 3D model pull requests, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
