### PR TITLE
Fix BarrelJack Wuerth Mounting Pin pad name

### DIFF
--- a/Connector_BarrelJack.pretty/BarrelJack_Wuerth_6941xx301002.kicad_mod
+++ b/Connector_BarrelJack.pretty/BarrelJack_Wuerth_6941xx301002.kicad_mod
@@ -31,7 +31,7 @@
   (fp_line (start 6.2 5.5) (end 5 5.5) (layer F.CrtYd) (width 0.05))
   (fp_line (start 6.2 0.5) (end 5 0.5) (layer F.CrtYd) (width 0.05))
   (fp_line (start -4.6 -1) (end -2.5 -1) (layer F.SilkS) (width 0.12))
-  (pad 3 thru_hole oval (at 4.8 3 90) (size 4 1.8) (drill oval 3 0.8) (layers *.Cu *.Mask))
+  (pad MP thru_hole oval (at 4.8 3 90) (size 4 1.8) (drill oval 3 0.8) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 0 5.8) (size 4 1.8) (drill oval 3 0.8) (layers *.Cu *.Mask))
   (pad 1 thru_hole rect (at 0 0) (size 4.4 1.8) (drill oval 3.4 0.8) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Connector_BarrelJack.3dshapes/BarrelJack_Wuerth_6941xx301002.wrl


### PR DESCRIPTION
Renames pad number 3 to MP, to match pad name on symbol Barrel_Jack_MountingPin

![barrel_jack_mp_symbol](https://user-images.githubusercontent.com/180601/45979965-085d0d00-c051-11e8-959b-ade69abeac7d.png)
![barrel_jack_mp_footprint](https://user-images.githubusercontent.com/180601/45979977-0eeb8480-c051-11e8-87e9-254b8cd54306.png)

And this this the fixed one. No more errors loading netlist in Pcbnew.

![barrel_jack_mp_footprint_new](https://user-images.githubusercontent.com/180601/45979988-127f0b80-c051-11e8-8605-aa681bff9bbd.png)


------------

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the footprint(s) you are contributing
- [x] An example screenshot image is very helpful 
- [ ] If there are matching symbol or 3D model pull requests, provide link(s) as appropriate
- [x] Check the output of the Travis automated check scripts - fix any errors as required
