### PR TITLE
Fix EP and Mask sizes for TPS703/704.

### DIFF
--- a/Package_SO.pretty/HTSSOP-24-1EP_4.4x7.8mm_P0.65mm_EP3.4x7.8mm_Mask2.4x4.68mm.kicad_mod
+++ b/Package_SO.pretty/HTSSOP-24-1EP_4.4x7.8mm_P0.65mm_EP3.4x7.8mm_Mask2.4x4.68mm.kicad_mod
@@ -1,11 +1,11 @@
-(module HTSSOP-24-1EP_4.4x7.8mm_P0.65mm_EP2.4x4.68mm_Mask3.4x7.8mm (layer F.Cu) (tedit 5BB78E7D)
+(module HTSSOP-24-1EP_4.4x7.8mm_P0.65mm_EP3.4x7.8mm_Mask2.4x4.68mm (layer F.Cu) (tedit 5BB78E7D)
   (descr "HTSSOP, 24 Pin (http://www.ti.com/lit/ds/symlink/tps703.pdf), generated with kicad-footprint-generator ipc_gullwing_generator.py")
   (tags "HTSSOP SO")
   (attr smd)
   (fp_text reference REF** (at 0 -4.85) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (fp_text value HTSSOP-24-1EP_4.4x7.8mm_P0.65mm_EP2.4x4.68mm_Mask3.4x7.8mm (at 0 4.85) (layer F.Fab)
+  (fp_text value HTSSOP-24-1EP_4.4x7.8mm_P0.65mm_EP3.4x7.8mm_Mask2.4x4.68mm (at 0 4.85) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
   (fp_line (start 0 4.035) (end 2.2 4.035) (layer F.SilkS) (width 0.12))
@@ -52,7 +52,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Package_SO.3dshapes/HTSSOP-24-1EP_4.4x7.8mm_P0.65mm_EP2.4x4.68mm_Mask3.4x7.8mm.wrl
+  (model ${KISYS3DMOD}/Package_SO.3dshapes/HTSSOP-24-1EP_4.4x7.8mm_P0.65mm_EP3.4x7.8mm_Mask2.4x4.68mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/Package_SO.pretty/HTSSOP-24-1EP_4.4x7.8mm_P0.65mm_EP3.4x7.8mm_Mask2.4x4.68mm_ThermalVias.kicad_mod
+++ b/Package_SO.pretty/HTSSOP-24-1EP_4.4x7.8mm_P0.65mm_EP3.4x7.8mm_Mask2.4x4.68mm_ThermalVias.kicad_mod
@@ -1,11 +1,11 @@
-(module HTSSOP-24-1EP_4.4x7.8mm_P0.65mm_EP2.4x4.68mm_Mask3.4x7.8mm_ThermalVias (layer F.Cu) (tedit 5BB78E7D)
+(module HTSSOP-24-1EP_4.4x7.8mm_P0.65mm_EP3.4x7.8mm_Mask2.4x4.68mm_ThermalVias (layer F.Cu) (tedit 5BB78E7D)
   (descr "HTSSOP, 24 Pin (http://www.ti.com/lit/ds/symlink/tps703.pdf), generated with kicad-footprint-generator ipc_gullwing_generator.py")
   (tags "HTSSOP SO")
   (attr smd)
   (fp_text reference REF** (at 0 -4.85) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (fp_text value HTSSOP-24-1EP_4.4x7.8mm_P0.65mm_EP2.4x4.68mm_Mask3.4x7.8mm_ThermalVias (at 0 4.85) (layer F.Fab)
+  (fp_text value HTSSOP-24-1EP_4.4x7.8mm_P0.65mm_EP3.4x7.8mm_Mask2.4x4.68mm_ThermalVias (at 0 4.85) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
   (fp_line (start 0 4.035) (end 2.2 4.035) (layer F.SilkS) (width 0.12))
@@ -71,7 +71,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Package_SO.3dshapes/HTSSOP-24-1EP_4.4x7.8mm_P0.65mm_EP2.4x4.68mm_Mask3.4x7.8mm.wrl
+  (model ${KISYS3DMOD}/Package_SO.3dshapes/HTSSOP-24-1EP_4.4x7.8mm_P0.65mm_EP3.4x7.8mm_Mask2.4x4.68mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))


### PR DESCRIPTION
Messed up the footprint names at https://github.com/KiCad/kicad-footprints/pull/995. This fixes them.

http://www.ti.com/lit/ds/symlink/tps703.pdf

------------

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the footprint(s) you are contributing
- [ ] An example screenshot image is very helpful 
- [ ] If there are matching symbol or 3D model pull requests, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
