### PR TITLE
Fix Kingbright APFA3010 pad numbering

### DIFF
--- a/LED_SMD.pretty/LED_Kingbright_APFA3010_3x1.5mm_Horizontal.kicad_mod
+++ b/LED_SMD.pretty/LED_Kingbright_APFA3010_3x1.5mm_Horizontal.kicad_mod
@@ -1,4 +1,4 @@
-(module LED_Kingbright_APFA3010_3x1.5mm_Horizontal (layer F.Cu) (tedit 5A7CB8DD)
+(module LED_Kingbright_APFA3010_3x1.5mm_Horizontal (layer F.Cu) (tedit 5BE523DD)
   (descr "LED RGB, APFA3010, http://www.kingbrightusa.com/images/catalog/SPEC/APFA3010LSEEZGKQBKC.pdf")
   (tags "LED RGB APFA3010 KINGBRIGHT 3x1.5mm")
   (attr smd)
@@ -30,8 +30,8 @@
   (fp_line (start 1.5 -0.25) (end -1.5 -0.25) (layer F.Fab) (width 0.1))
   (fp_line (start 1.5 0.25) (end 1.5 -0.25) (layer F.Fab) (width 0.1))
   (fp_line (start -1.5 0.25) (end 1.5 0.25) (layer F.Fab) (width 0.1))
-  (pad 1 smd rect (at -1.5 0) (size 1 0.9) (layers F.Cu F.Paste F.Mask))
-  (pad 2 smd rect (at 1.5 0) (size 1 0.9) (layers F.Cu F.Paste F.Mask))
+  (pad 2 smd rect (at -1.5 0) (size 1 0.9) (layers F.Cu F.Paste F.Mask))
+  (pad 1 smd rect (at 1.5 0) (size 1 0.9) (layers F.Cu F.Paste F.Mask))
   (pad 3 smd rect (at -0.4 0.45) (size 0.4 0.8) (layers F.Cu F.Paste F.Mask))
   (pad 4 smd rect (at 0.4 0.45) (size 0.4 0.8) (layers F.Cu F.Paste F.Mask))
   (model ${KISYS3DMOD}/LED_SMD.3dshapes/LED_Kingbright_APFA3010_3x1.5mm_Horizontal.wrl


### PR DESCRIPTION
Flip pins 1 and 2 as per [the datasheet for APFA3010LSEEZGKQBKC](http://www.kingbrightusa.com/images/catalog/SPEC/APFA3010LSEEZGKQBKC.pdf).

![0xd31a028e](https://user-images.githubusercontent.com/124381/48246941-60f92700-e3bf-11e8-87a1-a5a802c39eee.png)