### PR TITLE
name mounting pads of PTSM SMD connectors with `MP`

### DIFF
--- a/TerminalBlock_Phoenix.pretty/TerminalBlock_Phoenix_PTSM-0,5-2-2,5-V-SMD_1x02_P2.50mm_Vertical.kicad_mod
+++ b/TerminalBlock_Phoenix.pretty/TerminalBlock_Phoenix_PTSM-0,5-2-2,5-V-SMD_1x02_P2.50mm_Vertical.kicad_mod
@@ -31,8 +31,8 @@
   (fp_line (start -3.75 -3.88) (end 4.75 -3.88) (layer F.SilkS) (width 0.12))
   (pad 2 smd rect (at 1.25 2.13 180) (size 1.4 3.4) (layers F.Cu F.Paste F.Mask))
   (pad 1 smd rect (at -1.25 2.13 180) (size 1.4 3.4) (layers F.Cu F.Paste F.Mask))
-  (pad "" smd rect (at 5.05 -1.03 180) (size 2.3 5.6) (layers F.Cu F.Paste F.Mask))
-  (pad "" smd rect (at -5.05 -1.03 180) (size 2.3 5.6) (layers F.Cu F.Paste F.Mask))
+  (pad MP smd rect (at 5.05 -1.03 180) (size 2.3 5.6) (layers F.Cu F.Paste F.Mask))
+  (pad MP smd rect (at -5.05 -1.03 180) (size 2.3 5.6) (layers F.Cu F.Paste F.Mask))
   (model ${KISYS3DMOD}/TerminalBlock_Phoenix.3dshapes/TerminalBlock_Phoenix_PTSM-0,5-2-2,5-V-SMD_1x02_P2.50mm_Vertical.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))

--- a/TerminalBlock_Phoenix.pretty/TerminalBlock_Phoenix_PTSM-0,5-2-HV-2.5-SMD_1x02_P2.50mm_Vertical.kicad_mod
+++ b/TerminalBlock_Phoenix.pretty/TerminalBlock_Phoenix_PTSM-0,5-2-HV-2.5-SMD_1x02_P2.50mm_Vertical.kicad_mod
@@ -40,8 +40,8 @@
   (pad "" np_thru_hole circle (at 2.65 1.05) (size 1 1) (drill 1) (layers *.Cu *.Mask))
   (pad 2 smd rect (at 1.25 1.65 180) (size 1.2 4.4) (layers F.Cu F.Paste F.Mask))
   (pad 1 smd rect (at -1.25 1.65 180) (size 1.2 4.4) (layers F.Cu F.Paste F.Mask))
-  (pad "" smd rect (at 4.55 -1.05 180) (size 2.2 5.6) (layers F.Cu F.Paste F.Mask))
-  (pad "" smd rect (at -4.55 -1.05 180) (size 2.2 5.6) (layers F.Cu F.Paste F.Mask))
+  (pad MP smd rect (at 4.55 -1.05 180) (size 2.2 5.6) (layers F.Cu F.Paste F.Mask))
+  (pad MP smd rect (at -4.55 -1.05 180) (size 2.2 5.6) (layers F.Cu F.Paste F.Mask))
   (pad "" np_thru_hole circle (at -2.65 1.05) (size 1 1) (drill 1) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/TerminalBlock_Phoenix.3dshapes/TerminalBlock_Phoenix_PTSM-0,5-2-HV-2.5-SMD_1x02_P2.50mm_Vertical.wrl
     (at (xyz 0 0 0))

--- a/TerminalBlock_Phoenix.pretty/TerminalBlock_Phoenix_PTSM-0,5-3-2,5-V-SMD_1x03_P2.50mm_Vertical.kicad_mod
+++ b/TerminalBlock_Phoenix.pretty/TerminalBlock_Phoenix_PTSM-0,5-3-2,5-V-SMD_1x03_P2.50mm_Vertical.kicad_mod
@@ -36,8 +36,8 @@
   (pad 3 smd rect (at 2.5 2.13 180) (size 1.4 3.4) (layers F.Cu F.Paste F.Mask))
   (pad 2 smd rect (at 0 2.13 180) (size 1.4 3.4) (layers F.Cu F.Paste F.Mask))
   (pad 1 smd rect (at -2.5 2.13 180) (size 1.4 3.4) (layers F.Cu F.Paste F.Mask))
-  (pad "" smd rect (at 6.3 -1.03 180) (size 2.3 5.6) (layers F.Cu F.Paste F.Mask))
-  (pad "" smd rect (at -6.3 -1.03 180) (size 2.3 5.6) (layers F.Cu F.Paste F.Mask))
+  (pad MP smd rect (at 6.3 -1.03 180) (size 2.3 5.6) (layers F.Cu F.Paste F.Mask))
+  (pad MP smd rect (at -6.3 -1.03 180) (size 2.3 5.6) (layers F.Cu F.Paste F.Mask))
   (model ${KISYS3DMOD}/TerminalBlock_Phoenix.3dshapes/TerminalBlock_Phoenix_PTSM-0,5-3-2,5-V-SMD_1x03_P2.50mm_Vertical.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))

--- a/TerminalBlock_Phoenix.pretty/TerminalBlock_Phoenix_PTSM-0,5-3-HV-2.5-SMD_1x03_P2.50mm_Vertical.kicad_mod
+++ b/TerminalBlock_Phoenix.pretty/TerminalBlock_Phoenix_PTSM-0,5-3-HV-2.5-SMD_1x03_P2.50mm_Vertical.kicad_mod
@@ -45,8 +45,8 @@
   (pad 3 smd rect (at 2.5 1.65 180) (size 1.2 4.4) (layers F.Cu F.Paste F.Mask))
   (pad 2 smd rect (at 0 1.65 180) (size 1.2 4.4) (layers F.Cu F.Paste F.Mask))
   (pad 1 smd rect (at -2.5 1.65 180) (size 1.2 4.4) (layers F.Cu F.Paste F.Mask))
-  (pad "" smd rect (at 5.8 -1.05 180) (size 2.2 5.6) (layers F.Cu F.Paste F.Mask))
-  (pad "" smd rect (at -5.8 -1.05 180) (size 2.2 5.6) (layers F.Cu F.Paste F.Mask))
+  (pad MP smd rect (at 5.8 -1.05 180) (size 2.2 5.6) (layers F.Cu F.Paste F.Mask))
+  (pad MP smd rect (at -5.8 -1.05 180) (size 2.2 5.6) (layers F.Cu F.Paste F.Mask))
   (pad "" np_thru_hole circle (at -3.9 1.05) (size 1 1) (drill 1) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/TerminalBlock_Phoenix.3dshapes/TerminalBlock_Phoenix_PTSM-0,5-3-HV-2.5-SMD_1x03_P2.50mm_Vertical.wrl
     (at (xyz 0 0 0))

--- a/TerminalBlock_Phoenix.pretty/TerminalBlock_Phoenix_PTSM-0,5-4-2,5-V-SMD_1x04_P2.50mm_Vertical.kicad_mod
+++ b/TerminalBlock_Phoenix.pretty/TerminalBlock_Phoenix_PTSM-0,5-4-2,5-V-SMD_1x04_P2.50mm_Vertical.kicad_mod
@@ -41,8 +41,8 @@
   (pad 3 smd rect (at 1.25 2.13 180) (size 1.4 3.4) (layers F.Cu F.Paste F.Mask))
   (pad 2 smd rect (at -1.25 2.13 180) (size 1.4 3.4) (layers F.Cu F.Paste F.Mask))
   (pad 1 smd rect (at -3.75 2.13 180) (size 1.4 3.4) (layers F.Cu F.Paste F.Mask))
-  (pad "" smd rect (at 7.55 -1.03 180) (size 2.3 5.6) (layers F.Cu F.Paste F.Mask))
-  (pad "" smd rect (at -7.55 -1.03 180) (size 2.3 5.6) (layers F.Cu F.Paste F.Mask))
+  (pad MP smd rect (at 7.55 -1.03 180) (size 2.3 5.6) (layers F.Cu F.Paste F.Mask))
+  (pad MP smd rect (at -7.55 -1.03 180) (size 2.3 5.6) (layers F.Cu F.Paste F.Mask))
   (model ${KISYS3DMOD}/TerminalBlock_Phoenix.3dshapes/TerminalBlock_Phoenix_PTSM-0,5-4-2,5-V-SMD_1x04_P2.50mm_Vertical.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))

--- a/TerminalBlock_Phoenix.pretty/TerminalBlock_Phoenix_PTSM-0,5-4-HV-2.5-SMD_1x04_P2.50mm_Vertical.kicad_mod
+++ b/TerminalBlock_Phoenix.pretty/TerminalBlock_Phoenix_PTSM-0,5-4-HV-2.5-SMD_1x04_P2.50mm_Vertical.kicad_mod
@@ -40,8 +40,8 @@
   (pad "" np_thru_hole circle (at 2.65 1.05) (size 1 1) (drill 1) (layers *.Cu *.Mask))
   (pad 2 smd rect (at 1.25 1.65 180) (size 1.2 4.4) (layers F.Cu F.Paste F.Mask))
   (pad 1 smd rect (at -1.25 1.65 180) (size 1.2 4.4) (layers F.Cu F.Paste F.Mask))
-  (pad "" smd rect (at 4.55 -1.05 180) (size 2.2 5.6) (layers F.Cu F.Paste F.Mask))
-  (pad "" smd rect (at -4.55 -1.05 180) (size 2.2 5.6) (layers F.Cu F.Paste F.Mask))
+  (pad MP smd rect (at 4.55 -1.05 180) (size 2.2 5.6) (layers F.Cu F.Paste F.Mask))
+  (pad MP smd rect (at -4.55 -1.05 180) (size 2.2 5.6) (layers F.Cu F.Paste F.Mask))
   (pad "" np_thru_hole circle (at -2.65 1.05) (size 1 1) (drill 1) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/TerminalBlock_Phoenix.3dshapes/TerminalBlock_Phoenix_PTSM-0,5-4-HV-2.5-SMD_1x04_P2.50mm_Vertical.wrl
     (at (xyz 0 0 0))

--- a/TerminalBlock_Phoenix.pretty/TerminalBlock_Phoenix_PTSM-0,5-5-2,5-V-SMD_1x05_P2.50mm_Vertical.kicad_mod
+++ b/TerminalBlock_Phoenix.pretty/TerminalBlock_Phoenix_PTSM-0,5-5-2,5-V-SMD_1x05_P2.50mm_Vertical.kicad_mod
@@ -46,8 +46,8 @@
   (pad 2 smd rect (at -2.5 2.13 180) (size 1.4 3.4) (layers F.Cu F.Paste F.Mask))
   (pad 5 smd rect (at 5 2.13 180) (size 1.4 3.4) (layers F.Cu F.Paste F.Mask))
   (pad 1 smd rect (at -5 2.13 180) (size 1.4 3.4) (layers F.Cu F.Paste F.Mask))
-  (pad "" smd rect (at 8.8 -1.03 180) (size 2.3 5.6) (layers F.Cu F.Paste F.Mask))
-  (pad "" smd rect (at -8.8 -1.03 180) (size 2.3 5.6) (layers F.Cu F.Paste F.Mask))
+  (pad MP smd rect (at 8.8 -1.03 180) (size 2.3 5.6) (layers F.Cu F.Paste F.Mask))
+  (pad MP smd rect (at -8.8 -1.03 180) (size 2.3 5.6) (layers F.Cu F.Paste F.Mask))
   (model ${KISYS3DMOD}/TerminalBlock_Phoenix.3dshapes/TerminalBlock_Phoenix_PTSM-0,5-5-2,5-V-SMD_1x05_P2.50mm_Vertical.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))

--- a/TerminalBlock_Phoenix.pretty/TerminalBlock_Phoenix_PTSM-0,5-5-HV-2.5-SMD_1x05_P2.50mm_Vertical.kicad_mod
+++ b/TerminalBlock_Phoenix.pretty/TerminalBlock_Phoenix_PTSM-0,5-5-HV-2.5-SMD_1x05_P2.50mm_Vertical.kicad_mod
@@ -55,8 +55,8 @@
   (pad 2 smd rect (at -2.5 1.65 180) (size 1.2 4.4) (layers F.Cu F.Paste F.Mask))
   (pad 5 smd rect (at 5 1.65 180) (size 1.2 4.4) (layers F.Cu F.Paste F.Mask))
   (pad 1 smd rect (at -5 1.65 180) (size 1.2 4.4) (layers F.Cu F.Paste F.Mask))
-  (pad "" smd rect (at 8.3 -1.05 180) (size 2.2 5.6) (layers F.Cu F.Paste F.Mask))
-  (pad "" smd rect (at -8.3 -1.05 180) (size 2.2 5.6) (layers F.Cu F.Paste F.Mask))
+  (pad MP smd rect (at 8.3 -1.05 180) (size 2.2 5.6) (layers F.Cu F.Paste F.Mask))
+  (pad MP smd rect (at -8.3 -1.05 180) (size 2.2 5.6) (layers F.Cu F.Paste F.Mask))
   (pad "" np_thru_hole circle (at -6.4 1.05) (size 1 1) (drill 1) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/TerminalBlock_Phoenix.3dshapes/TerminalBlock_Phoenix_PTSM-0,5-5-HV-2.5-SMD_1x05_P2.50mm_Vertical.wrl
     (at (xyz 0 0 0))

--- a/TerminalBlock_Phoenix.pretty/TerminalBlock_Phoenix_PTSM-0,5-6-2,5-V-SMD_1x06_P2.50mm_Vertical.kicad_mod
+++ b/TerminalBlock_Phoenix.pretty/TerminalBlock_Phoenix_PTSM-0,5-6-2,5-V-SMD_1x06_P2.50mm_Vertical.kicad_mod
@@ -51,8 +51,8 @@
   (pad 5 smd rect (at 3.75 2.13 180) (size 1.4 3.4) (layers F.Cu F.Paste F.Mask))
   (pad 6 smd rect (at 6.25 2.13 180) (size 1.4 3.4) (layers F.Cu F.Paste F.Mask))
   (pad 1 smd rect (at -6.25 2.13 180) (size 1.4 3.4) (layers F.Cu F.Paste F.Mask))
-  (pad "" smd rect (at 10.05 -1.03 180) (size 2.3 5.6) (layers F.Cu F.Paste F.Mask))
-  (pad "" smd rect (at -10.05 -1.03 180) (size 2.3 5.6) (layers F.Cu F.Paste F.Mask))
+  (pad MP smd rect (at 10.05 -1.03 180) (size 2.3 5.6) (layers F.Cu F.Paste F.Mask))
+  (pad MP smd rect (at -10.05 -1.03 180) (size 2.3 5.6) (layers F.Cu F.Paste F.Mask))
   (model ${KISYS3DMOD}/TerminalBlock_Phoenix.3dshapes/TerminalBlock_Phoenix_PTSM-0,5-6-2,5-V-SMD_1x06_P2.50mm_Vertical.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))

--- a/TerminalBlock_Phoenix.pretty/TerminalBlock_Phoenix_PTSM-0,5-6-HV-2.5-SMD_1x06_P2.50mm_Vertical.kicad_mod
+++ b/TerminalBlock_Phoenix.pretty/TerminalBlock_Phoenix_PTSM-0,5-6-HV-2.5-SMD_1x06_P2.50mm_Vertical.kicad_mod
@@ -60,8 +60,8 @@
   (pad 5 smd rect (at 3.75 1.65 180) (size 1.2 4.4) (layers F.Cu F.Paste F.Mask))
   (pad 6 smd rect (at 6.25 1.65 180) (size 1.2 4.4) (layers F.Cu F.Paste F.Mask))
   (pad 1 smd rect (at -6.25 1.65 180) (size 1.2 4.4) (layers F.Cu F.Paste F.Mask))
-  (pad "" smd rect (at 9.55 -1.05 180) (size 2.2 5.6) (layers F.Cu F.Paste F.Mask))
-  (pad "" smd rect (at -9.55 -1.05 180) (size 2.2 5.6) (layers F.Cu F.Paste F.Mask))
+  (pad MP smd rect (at 9.55 -1.05 180) (size 2.2 5.6) (layers F.Cu F.Paste F.Mask))
+  (pad MP smd rect (at -9.55 -1.05 180) (size 2.2 5.6) (layers F.Cu F.Paste F.Mask))
   (pad "" np_thru_hole circle (at -7.65 1.05) (size 1 1) (drill 1) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/TerminalBlock_Phoenix.3dshapes/TerminalBlock_Phoenix_PTSM-0,5-6-HV-2.5-SMD_1x06_P2.50mm_Vertical.wrl
     (at (xyz 0 0 0))

--- a/TerminalBlock_Phoenix.pretty/TerminalBlock_Phoenix_PTSM-0,5-7-2,5-V-SMD_1x07_P2.50mm_Vertical.kicad_mod
+++ b/TerminalBlock_Phoenix.pretty/TerminalBlock_Phoenix_PTSM-0,5-7-2,5-V-SMD_1x07_P2.50mm_Vertical.kicad_mod
@@ -56,8 +56,8 @@
   (pad 6 smd rect (at 5 2.13 180) (size 1.4 3.4) (layers F.Cu F.Paste F.Mask))
   (pad 7 smd rect (at 7.5 2.13 180) (size 1.4 3.4) (layers F.Cu F.Paste F.Mask))
   (pad 1 smd rect (at -7.5 2.13 180) (size 1.4 3.4) (layers F.Cu F.Paste F.Mask))
-  (pad "" smd rect (at 11.3 -1.03 180) (size 2.3 5.6) (layers F.Cu F.Paste F.Mask))
-  (pad "" smd rect (at -11.3 -1.03 180) (size 2.3 5.6) (layers F.Cu F.Paste F.Mask))
+  (pad MP smd rect (at 11.3 -1.03 180) (size 2.3 5.6) (layers F.Cu F.Paste F.Mask))
+  (pad MP smd rect (at -11.3 -1.03 180) (size 2.3 5.6) (layers F.Cu F.Paste F.Mask))
   (model ${KISYS3DMOD}/TerminalBlock_Phoenix.3dshapes/TerminalBlock_Phoenix_PTSM-0,5-7-2,5-V-SMD_1x07_P2.50mm_Vertical.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))

--- a/TerminalBlock_Phoenix.pretty/TerminalBlock_Phoenix_PTSM-0,5-7-HV-2.5-SMD_1x07_P2.50mm_Vertical.kicad_mod
+++ b/TerminalBlock_Phoenix.pretty/TerminalBlock_Phoenix_PTSM-0,5-7-HV-2.5-SMD_1x07_P2.50mm_Vertical.kicad_mod
@@ -65,8 +65,8 @@
   (pad 6 smd rect (at 5 1.65 180) (size 1.2 4.4) (layers F.Cu F.Paste F.Mask))
   (pad 7 smd rect (at 7.5 1.65 180) (size 1.2 4.4) (layers F.Cu F.Paste F.Mask))
   (pad 1 smd rect (at -7.5 1.65 180) (size 1.2 4.4) (layers F.Cu F.Paste F.Mask))
-  (pad "" smd rect (at 10.8 -1.05 180) (size 2.2 5.6) (layers F.Cu F.Paste F.Mask))
-  (pad "" smd rect (at -10.8 -1.05 180) (size 2.2 5.6) (layers F.Cu F.Paste F.Mask))
+  (pad MP smd rect (at 10.8 -1.05 180) (size 2.2 5.6) (layers F.Cu F.Paste F.Mask))
+  (pad MP smd rect (at -10.8 -1.05 180) (size 2.2 5.6) (layers F.Cu F.Paste F.Mask))
   (pad "" np_thru_hole circle (at -8.9 1.05) (size 1 1) (drill 1) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/TerminalBlock_Phoenix.3dshapes/TerminalBlock_Phoenix_PTSM-0,5-7-HV-2.5-SMD_1x07_P2.50mm_Vertical.wrl
     (at (xyz 0 0 0))

--- a/TerminalBlock_Phoenix.pretty/TerminalBlock_Phoenix_PTSM-0,5-8-2,5-V-SMD_1x08_P2.50mm_Vertical.kicad_mod
+++ b/TerminalBlock_Phoenix.pretty/TerminalBlock_Phoenix_PTSM-0,5-8-2,5-V-SMD_1x08_P2.50mm_Vertical.kicad_mod
@@ -61,8 +61,8 @@
   (pad 7 smd rect (at 6.25 2.13 180) (size 1.4 3.4) (layers F.Cu F.Paste F.Mask))
   (pad 8 smd rect (at 8.75 2.13 180) (size 1.4 3.4) (layers F.Cu F.Paste F.Mask))
   (pad 1 smd rect (at -8.75 2.13 180) (size 1.4 3.4) (layers F.Cu F.Paste F.Mask))
-  (pad "" smd rect (at 12.55 -1.03 180) (size 2.3 5.6) (layers F.Cu F.Paste F.Mask))
-  (pad "" smd rect (at -12.55 -1.03 180) (size 2.3 5.6) (layers F.Cu F.Paste F.Mask))
+  (pad MP smd rect (at 12.55 -1.03 180) (size 2.3 5.6) (layers F.Cu F.Paste F.Mask))
+  (pad MP smd rect (at -12.55 -1.03 180) (size 2.3 5.6) (layers F.Cu F.Paste F.Mask))
   (model ${KISYS3DMOD}/TerminalBlock_Phoenix.3dshapes/TerminalBlock_Phoenix_PTSM-0,5-8-2,5-V-SMD_1x08_P2.50mm_Vertical.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))

--- a/TerminalBlock_Phoenix.pretty/TerminalBlock_Phoenix_PTSM-0,5-8-HV-2.5-SMD_1x08_P2.50mm_Vertical.kicad_mod
+++ b/TerminalBlock_Phoenix.pretty/TerminalBlock_Phoenix_PTSM-0,5-8-HV-2.5-SMD_1x08_P2.50mm_Vertical.kicad_mod
@@ -70,8 +70,8 @@
   (pad 7 smd rect (at 6.25 1.65 180) (size 1.2 4.4) (layers F.Cu F.Paste F.Mask))
   (pad 8 smd rect (at 8.75 1.65 180) (size 1.2 4.4) (layers F.Cu F.Paste F.Mask))
   (pad 1 smd rect (at -8.75 1.65 180) (size 1.2 4.4) (layers F.Cu F.Paste F.Mask))
-  (pad "" smd rect (at 12.05 -1.05 180) (size 2.2 5.6) (layers F.Cu F.Paste F.Mask))
-  (pad "" smd rect (at -12.05 -1.05 180) (size 2.2 5.6) (layers F.Cu F.Paste F.Mask))
+  (pad MP smd rect (at 12.05 -1.05 180) (size 2.2 5.6) (layers F.Cu F.Paste F.Mask))
+  (pad MP smd rect (at -12.05 -1.05 180) (size 2.2 5.6) (layers F.Cu F.Paste F.Mask))
   (pad "" np_thru_hole circle (at -10.15 1.05) (size 1 1) (drill 1) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/TerminalBlock_Phoenix.3dshapes/TerminalBlock_Phoenix_PTSM-0,5-8-HV-2.5-SMD_1x08_P2.50mm_Vertical.wrl
     (at (xyz 0 0 0))


### PR DESCRIPTION
name mounting pads of PTSM SMD connectors (`TerminalBlock_Phoenix.pretty`) with `MP`

fix for #1087 

Generator script will follow later.