### PR TITLE
Fix pinout of PJ320D audio jack

### DIFF
--- a/Connector_Audio.pretty/Jack_3.5mm_PJ320D_Horizontal.kicad_mod
+++ b/Connector_Audio.pretty/Jack_3.5mm_PJ320D_Horizontal.kicad_mod
@@ -1,4 +1,4 @@
-(module Jack_3.5mm_PJ320D_Horizontal (layer F.Cu) (tedit 5BF5E15D)
+(module Jack_3.5mm_PJ320D_Horizontal (layer F.Cu) (tedit 5C06A514)
   (descr "Headphones with microphone connector, 3.5mm, 4 pins (http://www.qingpu-electronics.com/en/products/WQP-PJ320D-72.html)")
   (tags "3.5mm jack mic microphone phones headphones 4pins audio plug")
   (attr smd)
@@ -37,10 +37,10 @@
   (fp_line (start -6.375 -2.5) (end -8.375 -2.5) (layer F.SilkS) (width 0.12))
   (fp_line (start -6.375 2.5) (end -8.375 2.5) (layer F.SilkS) (width 0.12))
   (fp_circle (center 3.9 -2.35) (end 3.95 -2.1) (layer F.Fab) (width 0.12))
-  (pad R2 smd rect (at 4.925 3.25) (size 1.2 2.5) (layers F.Cu F.Paste F.Mask))
+  (pad S smd rect (at 4.925 3.25) (size 1.2 2.5) (layers F.Cu F.Paste F.Mask))
   (pad T smd rect (at 3.825 -3.25) (size 1.2 2.5) (layers F.Cu F.Paste F.Mask))
   (pad R1 smd rect (at -0.175 -3.25) (size 1.2 2.5) (layers F.Cu F.Paste F.Mask))
-  (pad S smd rect (at -3.175 -3.25) (size 1.2 2.5) (layers F.Cu F.Paste F.Mask))
+  (pad R2 smd rect (at -3.175 -3.25) (size 1.2 2.5) (layers F.Cu F.Paste F.Mask))
   (pad "" np_thru_hole circle (at -4.775 0) (size 1.5 1.5) (drill 1.5) (layers *.Cu *.Mask))
   (pad "" np_thru_hole circle (at 2.225 0) (size 1.5 1.5) (drill 1.5) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Connector_Audio.3dshapes/Jack_3.5mm_PJ320D_Horizontal.wrl


### PR DESCRIPTION
This is a followup to #1014.

I sent an email to Wenzhou QuinPu because I suspected that there was an error on the [WQP-PJ320D product page](http://www.qingpu-electronics.com/en/products/WQP-PJ320D-72.html) that showed the wrong pinout. They sent me [this datasheet](https://github.com/KiCad/kicad-footprints/files/2644866/WQP-PJ320D.pdf) which shows a different pinout which matches two other PJ320D manufacturers ([XKB](https://lcsc.com/product-detail/Audio-Video-Connectors_XKB-Enterprise-PJ-320D-X_C319111.html) and [Korean Hroparts](https://lcsc.com/product-detail/Audio-Video-Connectors_Korean-Hroparts-Elec-PJ-320D-4A_C95562.html)) as well as a connector I own from an unknown manufacturer.

I have suggested to Wenzhou QuinPu that they should update their product page.

This is the correct pinout:

![PJ320D at commit 46d25b5](https://user-images.githubusercontent.com/26132344/49455778-5c047900-f7ad-11e8-94c2-12722592f0d1.png)

------------

- [x] Provide a URL to a datasheet for the footprint(s) you are contributing
- [x] An example screenshot image is very helpful 
- [x] If there are matching symbol or 3D model pull requests, provide link(s) as appropriate
- [x] Check the output of the Travis automated check scripts - fix any errors as required
