### PR TITLE
Battery3 d

### DIFF
--- a/Battery.pretty/BatteryHolder_Bulgin_BX0036_1xC.kicad_mod
+++ b/Battery.pretty/BatteryHolder_Bulgin_BX0036_1xC.kicad_mod
@@ -1,5 +1,5 @@
-(module BatteryHolder_Bulgin_BX0036_1xC (layer F.Cu) (tedit 59653AC9)
-  (descr "Bulgin Battery Holder, BX0036, Battery Type C (http://www.bulgin.com/media/bulgin/data/Battery_holders.pdf)")
+(module BatteryHolder_Bulgin_BX0036_1xC (layer F.Cu) (tedit 5C0C1564)
+  (descr "Bulgin Battery Holder, BX0036, Battery Type C (https://www.bulgin.com/products/pub/media/bulgin/data/Battery_holders.pdf)")
   (tags "Bulgin BX0036")
   (fp_text reference REF** (at 27.8 -18.1) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))

--- a/Battery.pretty/BatteryHolder_Keystone_500.kicad_mod
+++ b/Battery.pretty/BatteryHolder_Keystone_500.kicad_mod
@@ -1,4 +1,4 @@
-(module BatteryHolder_Keystone_500 (layer F.Cu) (tedit 5B25584F)
+(module BatteryHolder_Keystone_500 (layer F.Cu) (tedit 5C1118DA)
   (descr "Keystone #500, CR1220 battery holder, http://www.keyelco.com/product-pdf.cfm?p=710")
   (tags "CR1220 battery holder")
   (fp_text reference REF** (at -0.35 -3.6) (layer F.SilkS)
@@ -31,11 +31,8 @@
   (fp_circle (center 9.53 0) (end 2.41 2.54) (layer F.Fab) (width 0.1))
   (fp_arc (start 9.53 0) (end 2.18 -2.85) (angle 317) (layer F.CrtYd) (width 0.05))
   (fp_arc (start 9.53 0) (end 2.33 -2.6) (angle 320) (layer F.SilkS) (width 0.12))
-  (pad 1 thru_hole circle (at 0 0) (size 3.56 3.56) (drill 2.54) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 0) (size 2.5 2.5) (drill 1.02) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 9.53 0) (size 2.54 2.54) (drill 1.02) (layers *.Cu *.Mask))
-  (pad "" np_thru_hole circle (at 9.53 5.08) (size 2.03 2.03) (drill 2.03) (layers *.Cu *.Mask))
-  (pad "" np_thru_hole circle (at 13.97 -2.54) (size 2.03 2.03) (drill 2.03) (layers *.Cu *.Mask))
-  (pad "" np_thru_hole circle (at 5.08 -2.54) (size 2.03 2.03) (drill 2.03) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Battery.3dshapes/BatteryHolder_Keystone_500.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))

--- a/Battery.pretty/BatteryHolder_MPD_BH-18650-PC2.kicad_mod
+++ b/Battery.pretty/BatteryHolder_MPD_BH-18650-PC2.kicad_mod
@@ -1,4 +1,4 @@
-(module BatteryHolder_MPD_BH-18650-PC2 (layer F.Cu) (tedit 5A562497)
+(module BatteryHolder_MPD_BH-18650-PC2 (layer F.Cu) (tedit 5C1007C1)
   (descr "18650 Battery Holder (http://www.memoryprotectiondevices.com/datasheets/BK-18650-PC2-datasheet.pdf)")
   (tags "18650 Battery Holder")
   (fp_text reference REF** (at 36 1) (layer F.SilkS)
@@ -24,6 +24,8 @@
   )
   (pad 2 thru_hole circle (at 72 0) (size 3.5 3.5) (drill 2) (layers *.Cu *.Mask))
   (pad 1 thru_hole rect (at 0 0) (size 3.5 3.5) (drill 2) (layers *.Cu *.Mask))
+  (pad "" np_thru_hole circle (at 8.645 0) (size 3.2 3.2) (drill 3.2) (layers *.Cu *.Mask))
+  (pad "" np_thru_hole circle (at 64.255 0) (size 3.2 3.2) (drill 3.2) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Battery.3dshapes/BatteryHolder_MPD_BH-18650-PC2.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))


### PR DESCRIPTION
Small updates to battery foot prints

Battery.pretty/BatteryHolder_Bulgin_BX0036_1xC.kicad_mod
Changed the http to a valid 
http://www.bulgin.com/media/bulgin/data/Battery_holders.pdf

Battery.pretty/BatteryHolder_Keystone_500.kicad_mod
Removed the nptht holes 
I assume the original creator of the foot rpint thought the three 
plastic pins beneath the socket was sort of guidance holes.
they are not, they are there to make a distance between the belly and PCB
see "mounting details" in the data sheet (up to left)
http://www.keyelco.com/product-pdf.cfm?p=710

Battery.pretty/BatteryHolder_MPD_BH-18650-PC2.kicad_mod
Two npth holes was missing, see data sheet
http://www.memoryprotectiondevices.com/datasheets/BK-18650-PC2-datasheet.pdf


------------

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the footprint(s) you are contributing
- [ ] An example screenshot image is very helpful 
- [ ] If there are matching symbol or 3D model pull requests, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
