### PR TITLE
Scripted version of qfn-76 9x9 (3.8x3.8 EP)

### DIFF
--- a/Package_DFN_QFN.pretty/QFN-76-1EP_9x9mm_P0.4mm_EP3.8x3.8mm.kicad_mod
+++ b/Package_DFN_QFN.pretty/QFN-76-1EP_9x9mm_P0.4mm_EP3.8x3.8mm.kicad_mod
@@ -1,5 +1,5 @@
-(module QFN-76-1EP_9x9mm_P0.4mm_EP3.8x3.8mm (layer F.Cu) (tedit 5C27DBD8)
-  (descr "QFN, 76 Pin (https://www.marvell.com/documents/bqcwxsoiqfjkcjdjhkvc/), generated with kicad-footprint-generator ipc_dfn_qfn_generator.py")
+(module QFN-76-1EP_9x9mm_P0.4mm_EP3.8x3.8mm (layer F.Cu) (tedit 5C28E194)
+  (descr "QFN, 76 Pin (https://www.marvell.com/documents/bqcwxsoiqfjkcjdjhkvc/#page=19), generated with kicad-footprint-generator ipc_dfn_qfn_generator.py")
   (tags "QFN DFN_QFN")
   (attr smd)
   (fp_text reference REF** (at 0 -5.8) (layer F.SilkS)

--- a/Package_DFN_QFN.pretty/QFN-76-1EP_9x9mm_P0.4mm_EP3.8x3.8mm_ThermalVias.kicad_mod
+++ b/Package_DFN_QFN.pretty/QFN-76-1EP_9x9mm_P0.4mm_EP3.8x3.8mm_ThermalVias.kicad_mod
@@ -1,5 +1,5 @@
-(module QFN-76-1EP_9x9mm_P0.4mm_EP3.8x3.8mm_ThermalVias (layer F.Cu) (tedit 5C27DBD8)
-  (descr "QFN, 76 Pin (https://www.marvell.com/documents/bqcwxsoiqfjkcjdjhkvc/), generated with kicad-footprint-generator ipc_dfn_qfn_generator.py")
+(module QFN-76-1EP_9x9mm_P0.4mm_EP3.8x3.8mm_ThermalVias (layer F.Cu) (tedit 5C28E194)
+  (descr "QFN, 76 Pin (https://www.marvell.com/documents/bqcwxsoiqfjkcjdjhkvc/#page=19), generated with kicad-footprint-generator ipc_dfn_qfn_generator.py")
   (tags "QFN DFN_QFN")
   (attr smd)
   (fp_text reference REF** (at 0 -5.8) (layer F.SilkS)

--- a/Package_DFN_QFN.pretty/QFN-76-1EP_9x9mm_P0.4mm_EP3.8x3.8mm_ThermalVias.kicad_mod
+++ b/Package_DFN_QFN.pretty/QFN-76-1EP_9x9mm_P0.4mm_EP3.8x3.8mm_ThermalVias.kicad_mod
@@ -1,11 +1,11 @@
-(module QFN-76-1EP_9x9mm_P0.4mm_EP3.8x3.8mm (layer F.Cu) (tedit 5C27DBD8)
+(module QFN-76-1EP_9x9mm_P0.4mm_EP3.8x3.8mm_ThermalVias (layer F.Cu) (tedit 5C27DBD8)
   (descr "QFN, 76 Pin (https://www.marvell.com/documents/bqcwxsoiqfjkcjdjhkvc/), generated with kicad-footprint-generator ipc_dfn_qfn_generator.py")
   (tags "QFN DFN_QFN")
   (attr smd)
   (fp_text reference REF** (at 0 -5.8) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (fp_text value QFN-76-1EP_9x9mm_P0.4mm_EP3.8x3.8mm (at 0 5.8) (layer F.Fab)
+  (fp_text value QFN-76-1EP_9x9mm_P0.4mm_EP3.8x3.8mm_ThermalVias (at 0 5.8) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
   (fp_line (start 3.96 -4.61) (end 4.61 -4.61) (layer F.SilkS) (width 0.12))
@@ -25,15 +25,104 @@
   (fp_line (start 5.1 5.1) (end 5.1 -5.1) (layer F.CrtYd) (width 0.05))
   (fp_line (start 5.1 -5.1) (end -5.1 -5.1) (layer F.CrtYd) (width 0.05))
   (pad 77 smd roundrect (at 0 0) (size 3.8 3.8) (layers F.Cu F.Mask) (roundrect_rratio 0.065789))
-  (pad "" smd roundrect (at -1.27 -1.27) (size 1.02 1.02) (layers F.Paste) (roundrect_rratio 0.245098))
-  (pad "" smd roundrect (at -1.27 0) (size 1.02 1.02) (layers F.Paste) (roundrect_rratio 0.245098))
-  (pad "" smd roundrect (at -1.27 1.27) (size 1.02 1.02) (layers F.Paste) (roundrect_rratio 0.245098))
-  (pad "" smd roundrect (at 0 -1.27) (size 1.02 1.02) (layers F.Paste) (roundrect_rratio 0.245098))
-  (pad "" smd roundrect (at 0 0) (size 1.02 1.02) (layers F.Paste) (roundrect_rratio 0.245098))
-  (pad "" smd roundrect (at 0 1.27) (size 1.02 1.02) (layers F.Paste) (roundrect_rratio 0.245098))
-  (pad "" smd roundrect (at 1.27 -1.27) (size 1.02 1.02) (layers F.Paste) (roundrect_rratio 0.245098))
-  (pad "" smd roundrect (at 1.27 0) (size 1.02 1.02) (layers F.Paste) (roundrect_rratio 0.245098))
-  (pad "" smd roundrect (at 1.27 1.27) (size 1.02 1.02) (layers F.Paste) (roundrect_rratio 0.245098))
+  (pad 77 thru_hole circle (at -1.2 -1.2) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
+  (pad 77 thru_hole circle (at 0 -1.2) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
+  (pad 77 thru_hole circle (at 1.2 -1.2) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
+  (pad 77 thru_hole circle (at -1.2 0) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
+  (pad 77 thru_hole circle (at 0 0) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
+  (pad 77 thru_hole circle (at 1.2 0) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
+  (pad 77 thru_hole circle (at -1.2 1.2) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
+  (pad 77 thru_hole circle (at 0 1.2) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
+  (pad 77 thru_hole circle (at 1.2 1.2) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
+  (pad 77 smd roundrect (at 0 0) (size 2.9 2.9) (layers B.Cu) (roundrect_rratio 0.086207))
+  (pad "" smd roundrect (at -0.6 -0.6) (size 0.967471 0.967471) (layers F.Paste) (roundrect_rratio 0.25))
+  (pad "" smd roundrect (at -0.6 0.6) (size 0.967471 0.967471) (layers F.Paste) (roundrect_rratio 0.25))
+  (pad "" smd roundrect (at 0.6 -0.6) (size 0.967471 0.967471) (layers F.Paste) (roundrect_rratio 0.25))
+  (pad "" smd roundrect (at 0.6 0.6) (size 0.967471 0.967471) (layers F.Paste) (roundrect_rratio 0.25))
+  (pad "" smd custom (at -1.55 -0.6) (size 0.494526 0.494526) (layers F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.212347 -0.413904) (xy 0.154497 -0.413904) (xy 0.212347 -0.356053) (xy 0.212347 0.356053)
+         (xy 0.154497 0.413904) (xy -0.212347 0.413904)) (width 0.139664))
+    ))
+  (pad "" smd custom (at -1.55 0.6) (size 0.494526 0.494526) (layers F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.212347 -0.413904) (xy 0.154497 -0.413904) (xy 0.212347 -0.356053) (xy 0.212347 0.356053)
+         (xy 0.154497 0.413904) (xy -0.212347 0.413904)) (width 0.139664))
+    ))
+  (pad "" smd custom (at 1.55 -0.6) (size 0.494526 0.494526) (layers F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.212347 -0.356053) (xy -0.154497 -0.413904) (xy 0.212347 -0.413904) (xy 0.212347 0.413904)
+         (xy -0.154497 0.413904) (xy -0.212347 0.356053)) (width 0.139664))
+    ))
+  (pad "" smd custom (at 1.55 0.6) (size 0.494526 0.494526) (layers F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.212347 -0.356053) (xy -0.154497 -0.413904) (xy 0.212347 -0.413904) (xy 0.212347 0.413904)
+         (xy -0.154497 0.413904) (xy -0.212347 0.356053)) (width 0.139664))
+    ))
+  (pad "" smd custom (at -0.6 -1.55) (size 0.494526 0.494526) (layers F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.413904 -0.212347) (xy 0.413904 -0.212347) (xy 0.413904 0.154497) (xy 0.356053 0.212347)
+         (xy -0.356053 0.212347) (xy -0.413904 0.154497)) (width 0.139664))
+    ))
+  (pad "" smd custom (at 0.6 -1.55) (size 0.494526 0.494526) (layers F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.413904 -0.212347) (xy 0.413904 -0.212347) (xy 0.413904 0.154497) (xy 0.356053 0.212347)
+         (xy -0.356053 0.212347) (xy -0.413904 0.154497)) (width 0.139664))
+    ))
+  (pad "" smd custom (at -0.6 1.55) (size 0.494526 0.494526) (layers F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.413904 -0.154497) (xy -0.356053 -0.212347) (xy 0.356053 -0.212347) (xy 0.413904 -0.154497)
+         (xy 0.413904 0.212347) (xy -0.413904 0.212347)) (width 0.139664))
+    ))
+  (pad "" smd custom (at 0.6 1.55) (size 0.494526 0.494526) (layers F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.413904 -0.154497) (xy -0.356053 -0.212347) (xy 0.356053 -0.212347) (xy 0.413904 -0.154497)
+         (xy 0.413904 0.212347) (xy -0.413904 0.212347)) (width 0.139664))
+    ))
+  (pad "" smd custom (at -1.55 -1.55) (size 0.460271 0.460271) (layers F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.178092 -0.178092) (xy 0.178092 -0.178092) (xy 0.178092 0.091864) (xy 0.091864 0.178092)
+         (xy -0.178092 0.178092)) (width 0.208173))
+    ))
+  (pad "" smd custom (at -1.55 1.55) (size 0.460271 0.460271) (layers F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.178092 -0.178092) (xy 0.091864 -0.178092) (xy 0.178092 -0.091864) (xy 0.178092 0.178092)
+         (xy -0.178092 0.178092)) (width 0.208173))
+    ))
+  (pad "" smd custom (at 1.55 -1.55) (size 0.460271 0.460271) (layers F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.178092 -0.178092) (xy 0.178092 -0.178092) (xy 0.178092 0.178092) (xy -0.091864 0.178092)
+         (xy -0.178092 0.091864)) (width 0.208173))
+    ))
+  (pad "" smd custom (at 1.55 1.55) (size 0.460271 0.460271) (layers F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.178092 -0.091864) (xy -0.091864 -0.178092) (xy 0.178092 -0.178092) (xy 0.178092 0.178092)
+         (xy -0.178092 0.178092)) (width 0.208173))
+    ))
   (pad 1 smd roundrect (at -4.4375 -3.6) (size 0.825 0.2) (layers F.Cu F.Mask F.Paste) (roundrect_rratio 0.25))
   (pad 2 smd roundrect (at -4.4375 -3.2) (size 0.825 0.2) (layers F.Cu F.Mask F.Paste) (roundrect_rratio 0.25))
   (pad 3 smd roundrect (at -4.4375 -2.8) (size 0.825 0.2) (layers F.Cu F.Mask F.Paste) (roundrect_rratio 0.25))


### PR DESCRIPTION
This footprint is not used by any symbol. Still included as the
datasheet is valid.

Script PR: https://github.com/pointhi/kicad-footprint-generator/pull/250

https://www.marvell.com/documents/bqcwxsoiqfjkcjdjhkvc/

![screenshot from 2018-12-29 21-38-36](https://user-images.githubusercontent.com/18327350/50541999-2c7d3c80-0bb2-11e9-80ec-531b4b3da618.png)

```yaml
QFN-76-1EP_9x9mm_P0.4mm_EP3.8x3.8mm:
  device_type: 'QFN'
  #manufacturer: 'man'
  #part_number: 'mpn'
  size_source: 'https://www.marvell.com/documents/bqcwxsoiqfjkcjdjhkvc/'
  ipc_class: 'qfn' # 'qfn_pull_back'
  #ipc_density: 'least' #overwrite global value for this device.
  # custom_name_format:
  body_size_x:
    nominal: 9
    tolerance: 0
  body_size_y:
    nominal: 9
    tolerance: 0
  body_height:
    minimum: 0.8
    nominal: 0.85
    maximum: 1

  lead_width:
    minimum: 0.15
    nominal: 0.2
    maximum: 0.25
  lead_len:
    nominal: 0.4
    tolerance: 0.1

  EP_size_x:
    nominal: 3.8
    tolerance: 0.2
  EP_size_y:
    nominal: 3.8
    tolerance: 0.2
  # EP_paste_coverage: 0.65
  EP_num_paste_pads: [3, 3]
  #heel_reduction: 0.1 #for relatively large EP pads (increase clearance)

  thermal_vias:
    count: [3, 3]
    drill: 0.2
    # min_annular_ring: 0.15
    paste_via_clearance: 0.1
    # EP_num_paste_pads: [2, 2]
    paste_between_vias: 1
    paste_rings_outside: 1
    #EP_paste_coverage: 0.6
    grid: [1.2, 1.2]
    # bottom_pad_size:
    paste_avoid_via: True

  pitch: 0.4
  num_pins_x: 19
  num_pins_y: 19
```