### PR TITLE
Move Sierra XA11X0 to RF_GPS

### DIFF
--- a/RF_GPS.pretty/Sierra_XA11X0.kicad_mod
+++ b/RF_GPS.pretty/Sierra_XA11X0.kicad_mod
@@ -1,4 +1,4 @@
-(module Sierra_XA11X0 (layer F.Cu) (tedit 5C2781A8)
+(module Sierra_XA11X0 (layer F.Cu) (tedit 5C335553)
   (descr "QFN-24, Pitch 1.20 no EP, https://source.sierrawireless.com/resources/airprime/hardware_specs_user_guides/airprime_xm1100_product_technical_specification")
   (tags "QFN-24 P1.20")
   (attr smd)
@@ -51,7 +51,7 @@
   (pad 13 smd rect (at 6.25 3) (size 2 0.6) (layers F.Cu F.Paste F.Mask))
   (pad 12 smd rect (at 3.6 6.25) (size 0.6 2) (layers F.Cu F.Paste F.Mask))
   (pad 24 smd rect (at -3.6 -6.25) (size 0.6 2) (layers F.Cu F.Paste F.Mask))
-  (model ${KISYS3DMOD}/RF_Module.3dshapes/Sierra_XA11X0.wrl
+  (model ${KISYS3DMOD}/RF_GPS.3dshapes/Sierra_XA11X0.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))


### PR DESCRIPTION
Forgot to move Sierra XA11X0 from RF_Modules to RF_GPS

------------

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the footprint(s) you are contributing
- [ ] An example screenshot image is very helpful 
- [ ] If there are matching symbol or 3D model pull requests, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
