### PR TITLE
Set custom pad zone connect to "solid"

### DIFF
--- a/Jumper.pretty/SolderJumper-2_P1.3mm_Bridged2Bar_Pad1.0x1.5mm.kicad_mod
+++ b/Jumper.pretty/SolderJumper-2_P1.3mm_Bridged2Bar_Pad1.0x1.5mm.kicad_mod
@@ -17,6 +17,7 @@
   (fp_line (start 1.65 1.25) (end 1.65 -1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 1.65 1.25) (end -1.65 1.25) (layer F.CrtYd) (width 0.05))
   (pad 1 smd custom (at -0.65 0) (size 1 1.5) (layers F.Cu F.Mask)
+    (zone_connect 2)
     (options (clearance outline) (anchor rect))
     (primitives
       (gr_poly (pts

--- a/Jumper.pretty/SolderJumper-2_P1.3mm_Bridged2Bar_RoundedPad1.0x1.5mm.kicad_mod
+++ b/Jumper.pretty/SolderJumper-2_P1.3mm_Bridged2Bar_RoundedPad1.0x1.5mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 1.65 1.25) (end 1.65 -1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 1.65 1.25) (end -1.65 1.25) (layer F.CrtYd) (width 0.05))
   (pad 1 smd custom (at -0.65 0) (size 1 0.5) (layers F.Cu F.Mask)
-    (zone_connect 0)
+    (zone_connect 2)
     (options (clearance outline) (anchor rect))
     (primitives
       (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
@@ -34,7 +34,7 @@
          (xy 0.4 -0.6) (xy 0.9 -0.6) (xy 0.9 -0.2) (xy 0.4 -0.2)) (width 0))
     ))
   (pad 2 smd custom (at 0.65 0) (size 1 0.5) (layers F.Cu F.Mask)
-    (zone_connect 0)
+    (zone_connect 2)
     (options (clearance outline) (anchor rect))
     (primitives
       (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))

--- a/Jumper.pretty/SolderJumper-2_P1.3mm_Bridged_Pad1.0x1.5mm.kicad_mod
+++ b/Jumper.pretty/SolderJumper-2_P1.3mm_Bridged_Pad1.0x1.5mm.kicad_mod
@@ -17,6 +17,7 @@
   (fp_line (start 1.65 1.25) (end 1.65 -1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 1.65 1.25) (end -1.65 1.25) (layer F.CrtYd) (width 0.05))
   (pad 1 smd custom (at -0.65 0) (size 1 1.5) (layers F.Cu F.Mask)
+    (zone_connect 2)
     (options (clearance outline) (anchor rect))
     (primitives
       (gr_poly (pts

--- a/Jumper.pretty/SolderJumper-2_P1.3mm_Bridged_RoundedPad1.0x1.5mm.kicad_mod
+++ b/Jumper.pretty/SolderJumper-2_P1.3mm_Bridged_RoundedPad1.0x1.5mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 1.65 1.25) (end 1.65 -1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 1.65 1.25) (end -1.65 1.25) (layer F.CrtYd) (width 0.05))
   (pad 1 smd custom (at -0.65 0) (size 1 0.5) (layers F.Cu F.Mask)
-    (zone_connect 0)
+    (zone_connect 2)
     (options (clearance outline) (anchor rect))
     (primitives
       (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
@@ -32,7 +32,7 @@
          (xy 0.9 -0.3) (xy 0.4 -0.3) (xy 0.4 0.3) (xy 0.9 0.3)) (width 0))
     ))
   (pad 2 smd custom (at 0.65 0) (size 1 0.5) (layers F.Cu F.Mask)
-    (zone_connect 0)
+    (zone_connect 2)
     (options (clearance outline) (anchor rect))
     (primitives
       (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))

--- a/Jumper.pretty/SolderJumper-2_P1.3mm_Open_RoundedPad1.0x1.5mm.kicad_mod
+++ b/Jumper.pretty/SolderJumper-2_P1.3mm_Open_RoundedPad1.0x1.5mm.kicad_mod
@@ -21,7 +21,7 @@
   (fp_line (start 1.65 1.25) (end 1.65 -1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 1.65 1.25) (end -1.65 1.25) (layer F.CrtYd) (width 0.05))
   (pad 1 smd custom (at -0.65 0) (size 1 0.5) (layers F.Cu F.Mask)
-    (zone_connect 0)
+    (zone_connect 2)
     (options (clearance outline) (anchor rect))
     (primitives
       (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
@@ -30,7 +30,7 @@
          (xy 0 -0.75) (xy 0.5 -0.75) (xy 0.5 0.75) (xy 0 0.75)) (width 0))
     ))
   (pad 2 smd custom (at 0.65 0) (size 1 0.5) (layers F.Cu F.Mask)
-    (zone_connect 0)
+    (zone_connect 2)
     (options (clearance outline) (anchor rect))
     (primitives
       (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))

--- a/Jumper.pretty/SolderJumper-2_P1.3mm_Open_TrianglePad1.0x1.5mm.kicad_mod
+++ b/Jumper.pretty/SolderJumper-2_P1.3mm_Open_TrianglePad1.0x1.5mm.kicad_mod
@@ -17,7 +17,7 @@
   (fp_line (start 1.65 1.25) (end 1.65 -1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 1.65 1.25) (end -1.65 1.25) (layer F.CrtYd) (width 0.05))
   (pad 2 smd custom (at 0.725 0) (size 0.3 0.3) (layers F.Cu F.Mask)
-    (zone_connect 0)
+    (zone_connect 2)
     (options (clearance outline) (anchor rect))
     (primitives
       (gr_poly (pts
@@ -25,7 +25,7 @@
 ) (width 0))
     ))
   (pad 1 smd custom (at -0.725 0) (size 0.3 0.3) (layers F.Cu F.Mask)
-    (zone_connect 0)
+    (zone_connect 2)
     (options (clearance outline) (anchor rect))
     (primitives
       (gr_poly (pts

--- a/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged12_Pad1.0x1.5mm.kicad_mod
+++ b/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged12_Pad1.0x1.5mm.kicad_mod
@@ -20,6 +20,7 @@
   (fp_line (start 2.3 1.25) (end 2.3 -1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 2.3 1.25) (end -2.3 1.25) (layer F.CrtYd) (width 0.05))
   (pad 1 smd custom (at -1.3 0) (size 1 1.5) (layers F.Cu F.Mask)
+    (zone_connect 2)
     (options (clearance outline) (anchor rect))
     (primitives
       (gr_poly (pts

--- a/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged12_Pad1.0x1.5mm_NumberLabels.kicad_mod
+++ b/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged12_Pad1.0x1.5mm_NumberLabels.kicad_mod
@@ -23,6 +23,7 @@
   (fp_line (start 2.3 1.25) (end 2.3 -1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 2.3 1.25) (end -2.3 1.25) (layer F.CrtYd) (width 0.05))
   (pad 1 smd custom (at -1.3 0) (size 1 1.5) (layers F.Cu F.Mask)
+    (zone_connect 2)
     (options (clearance outline) (anchor rect))
     (primitives
       (gr_poly (pts

--- a/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged12_RoundedPad1.0x1.5mm.kicad_mod
+++ b/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged12_RoundedPad1.0x1.5mm.kicad_mod
@@ -24,7 +24,7 @@
   (fp_arc (start -1.35 0.3) (end -2.05 0.3) (angle -90) (layer F.SilkS) (width 0.12))
   (fp_arc (start -1.35 -0.3) (end -1.35 -1) (angle -90) (layer F.SilkS) (width 0.12))
   (pad 1 smd custom (at -1.3 0) (size 1 0.5) (layers F.Cu F.Mask)
-    (zone_connect 0)
+    (zone_connect 2)
     (options (clearance outline) (anchor rect))
     (primitives
       (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
@@ -35,7 +35,7 @@
          (xy 0.4 -0.3) (xy 0.9 -0.3) (xy 0.9 0.3) (xy 0.4 0.3)) (width 0))
     ))
   (pad 3 smd custom (at 1.3 0) (size 1 0.5) (layers F.Cu F.Mask)
-    (zone_connect 0)
+    (zone_connect 2)
     (options (clearance outline) (anchor rect))
     (primitives
       (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))

--- a/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged12_RoundedPad1.0x1.5mm_NumberLabels.kicad_mod
+++ b/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged12_RoundedPad1.0x1.5mm_NumberLabels.kicad_mod
@@ -27,7 +27,7 @@
   (fp_arc (start -1.35 0.3) (end -2.05 0.3) (angle -90) (layer F.SilkS) (width 0.12))
   (fp_arc (start -1.35 -0.3) (end -1.35 -1) (angle -90) (layer F.SilkS) (width 0.12))
   (pad 1 smd custom (at -1.3 0) (size 1 0.5) (layers F.Cu F.Mask)
-    (zone_connect 0)
+    (zone_connect 2)
     (options (clearance outline) (anchor rect))
     (primitives
       (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
@@ -38,7 +38,7 @@
          (xy 0.4 -0.3) (xy 0.9 -0.3) (xy 0.9 0.3) (xy 0.4 0.3)) (width 0))
     ))
   (pad 3 smd custom (at 1.3 0) (size 1 0.5) (layers F.Cu F.Mask)
-    (zone_connect 0)
+    (zone_connect 2)
     (options (clearance outline) (anchor rect))
     (primitives
       (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))

--- a/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged2Bar12_Pad1.0x1.5mm.kicad_mod
+++ b/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged2Bar12_Pad1.0x1.5mm.kicad_mod
@@ -20,6 +20,7 @@
   (fp_line (start 2.3 1.25) (end 2.3 -1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 2.3 1.25) (end -2.3 1.25) (layer F.CrtYd) (width 0.05))
   (pad 1 smd custom (at -1.3 0) (size 1 1.5) (layers F.Cu F.Mask)
+    (zone_connect 2)
     (options (clearance outline) (anchor rect))
     (primitives
       (gr_poly (pts

--- a/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged2Bar12_Pad1.0x1.5mm_NumberLabels.kicad_mod
+++ b/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged2Bar12_Pad1.0x1.5mm_NumberLabels.kicad_mod
@@ -23,6 +23,7 @@
   (fp_line (start 2.3 1.25) (end 2.3 -1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 2.3 1.25) (end -2.3 1.25) (layer F.CrtYd) (width 0.05))
   (pad 1 smd custom (at -1.3 0) (size 1 1.5) (layers F.Cu F.Mask)
+    (zone_connect 2)
     (options (clearance outline) (anchor rect))
     (primitives
       (gr_poly (pts

--- a/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged2Bar12_RoundedPad1.0x1.5mm.kicad_mod
+++ b/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged2Bar12_RoundedPad1.0x1.5mm.kicad_mod
@@ -24,7 +24,7 @@
   (fp_arc (start -1.35 0.3) (end -2.05 0.3) (angle -90) (layer F.SilkS) (width 0.12))
   (fp_arc (start -1.35 -0.3) (end -1.35 -1) (angle -90) (layer F.SilkS) (width 0.12))
   (pad 1 smd custom (at -1.3 0) (size 1 0.5) (layers F.Cu F.Mask)
-    (zone_connect 0)
+    (zone_connect 2)
     (options (clearance outline) (anchor rect))
     (primitives
       (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
@@ -37,7 +37,7 @@
          (xy 0.4 0.2) (xy 0.9 0.2) (xy 0.9 0.6) (xy 0.4 0.6)) (width 0))
     ))
   (pad 3 smd custom (at 1.3 0) (size 1 0.5) (layers F.Cu F.Mask)
-    (zone_connect 0)
+    (zone_connect 2)
     (options (clearance outline) (anchor rect))
     (primitives
       (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))

--- a/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged2Bar12_RoundedPad1.0x1.5mm_NumberLabels.kicad_mod
+++ b/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged2Bar12_RoundedPad1.0x1.5mm_NumberLabels.kicad_mod
@@ -27,7 +27,7 @@
   (fp_arc (start -1.35 0.3) (end -2.05 0.3) (angle -90) (layer F.SilkS) (width 0.12))
   (fp_arc (start -1.35 -0.3) (end -1.35 -1) (angle -90) (layer F.SilkS) (width 0.12))
   (pad 1 smd custom (at -1.3 0) (size 1 0.5) (layers F.Cu F.Mask)
-    (zone_connect 0)
+    (zone_connect 2)
     (options (clearance outline) (anchor rect))
     (primitives
       (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
@@ -40,7 +40,7 @@
          (xy 0.4 0.2) (xy 0.9 0.2) (xy 0.9 0.6) (xy 0.4 0.6)) (width 0))
     ))
   (pad 3 smd custom (at 1.3 0) (size 1 0.5) (layers F.Cu F.Mask)
-    (zone_connect 0)
+    (zone_connect 2)
     (options (clearance outline) (anchor rect))
     (primitives
       (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))

--- a/Jumper.pretty/SolderJumper-3_P1.3mm_Open_RoundedPad1.0x1.5mm.kicad_mod
+++ b/Jumper.pretty/SolderJumper-3_P1.3mm_Open_RoundedPad1.0x1.5mm.kicad_mod
@@ -24,7 +24,7 @@
   (fp_arc (start -1.35 0.3) (end -2.05 0.3) (angle -90) (layer F.SilkS) (width 0.12))
   (fp_arc (start -1.35 -0.3) (end -1.35 -1) (angle -90) (layer F.SilkS) (width 0.12))
   (pad 1 smd custom (at -1.3 0) (size 1 0.5) (layers F.Cu F.Mask)
-    (zone_connect 0)
+    (zone_connect 2)
     (options (clearance outline) (anchor rect))
     (primitives
       (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
@@ -33,7 +33,7 @@
          (xy 0.55 -0.75) (xy 0 -0.75) (xy 0 0.75) (xy 0.55 0.75)) (width 0))
     ))
   (pad 3 smd custom (at 1.3 0) (size 1 0.5) (layers F.Cu F.Mask)
-    (zone_connect 0)
+    (zone_connect 2)
     (options (clearance outline) (anchor rect))
     (primitives
       (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))

--- a/Jumper.pretty/SolderJumper-3_P1.3mm_Open_RoundedPad1.0x1.5mm_NumberLabels.kicad_mod
+++ b/Jumper.pretty/SolderJumper-3_P1.3mm_Open_RoundedPad1.0x1.5mm_NumberLabels.kicad_mod
@@ -27,7 +27,7 @@
   (fp_arc (start -1.35 0.3) (end -2.05 0.3) (angle -90) (layer F.SilkS) (width 0.12))
   (fp_arc (start -1.35 -0.3) (end -1.35 -1) (angle -90) (layer F.SilkS) (width 0.12))
   (pad 1 smd custom (at -1.3 0) (size 1 0.5) (layers F.Cu F.Mask)
-    (zone_connect 0)
+    (zone_connect 2)
     (options (clearance outline) (anchor rect))
     (primitives
       (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
@@ -36,7 +36,7 @@
          (xy 0.55 -0.75) (xy 0 -0.75) (xy 0 0.75) (xy 0.55 0.75)) (width 0))
     ))
   (pad 3 smd custom (at 1.3 0) (size 1 0.5) (layers F.Cu F.Mask)
-    (zone_connect 0)
+    (zone_connect 2)
     (options (clearance outline) (anchor rect))
     (primitives
       (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))

--- a/Jumper.pretty/SolderJumper-3_P2.0mm_Open_TrianglePad1.0x1.5mm.kicad_mod
+++ b/Jumper.pretty/SolderJumper-3_P2.0mm_Open_TrianglePad1.0x1.5mm.kicad_mod
@@ -22,7 +22,7 @@
   (pad "" smd rect (at 1.2 0) (size 1.5 1.5) (layers F.Mask))
   (pad "" smd rect (at -1.2 0) (size 1.5 1.5) (layers F.Mask))
   (pad 1 smd custom (at -2 0) (size 0.3 0.3) (layers F.Cu F.Mask)
-    (zone_connect 0)
+    (zone_connect 2)
     (options (clearance outline) (anchor rect))
     (primitives
       (gr_poly (pts
@@ -30,7 +30,7 @@
 ) (width 0))
     ))
   (pad 2 smd custom (at 0 0) (size 0.3 0.3) (layers F.Cu)
-    (zone_connect 0)
+    (zone_connect 2)
     (options (clearance outline) (anchor rect))
     (primitives
       (gr_poly (pts
@@ -38,7 +38,7 @@
          (xy -0.7 0)) (width 0))
     ))
   (pad 3 smd custom (at 2 0 180) (size 0.3 0.3) (layers F.Cu F.Mask)
-    (zone_connect 0)
+    (zone_connect 2)
     (options (clearance outline) (anchor rect))
     (primitives
       (gr_poly (pts

--- a/Jumper.pretty/SolderJumper-3_P2.0mm_Open_TrianglePad1.0x1.5mm_NumberLabels.kicad_mod
+++ b/Jumper.pretty/SolderJumper-3_P2.0mm_Open_TrianglePad1.0x1.5mm_NumberLabels.kicad_mod
@@ -25,7 +25,7 @@
   (pad "" smd rect (at 1.2 0) (size 1.5 1.5) (layers F.Mask))
   (pad "" smd rect (at -1.2 0) (size 1.5 1.5) (layers F.Mask))
   (pad 1 smd custom (at -2 0) (size 0.3 0.3) (layers F.Cu F.Mask)
-    (zone_connect 0)
+    (zone_connect 2)
     (options (clearance outline) (anchor rect))
     (primitives
       (gr_poly (pts
@@ -33,7 +33,7 @@
 ) (width 0))
     ))
   (pad 2 smd custom (at 0 0) (size 0.3 0.3) (layers F.Cu)
-    (zone_connect 0)
+    (zone_connect 2)
     (options (clearance outline) (anchor rect))
     (primitives
       (gr_poly (pts
@@ -41,7 +41,7 @@
          (xy -0.7 0)) (width 0))
     ))
   (pad 3 smd custom (at 2 0 180) (size 0.3 0.3) (layers F.Cu F.Mask)
-    (zone_connect 0)
+    (zone_connect 2)
     (options (clearance outline) (anchor rect))
     (primitives
       (gr_poly (pts


### PR DESCRIPTION
Fixes https://github.com/KiCad/kicad-footprints/issues/1341.

Right now these footprints don't connect to zones, and this addresses that.

---

All contributions to the kicad library must follow the [KiCad library convention](http://kicad-pcb.org/libraries/klc/)

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the footprint(s) you are contributing
- [ ] An example screenshot image is very helpful 
- [ ] If there are matching symbol or 3D model pull requests, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
- [ ] Give a reason behind any intentional library convention rule violation.
