### PR TITLE
Add: Build Script for salsa.debian.org

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,16 @@
+# Docker Image: stretch-slim
+image: debian:stretch-slim
+
+# Stages: Build
+stages:
+  - build
+
+# Build: kicad-footprints
+build:
+  stages: build
+  script:
+    - apt-get install git -y
+    - git clone --depth 1 https://github.com/KiCad/kicad-library-utils /home/travis/build/kicad-library-utils
+    - bash /home/travis/build/kicad-library-utils/pcb/travis/check_all.sh $TRAVIS_BUILD_DIR -v
+    - python /home/travis/build/kicad-library-utils/check_lib_table.py $TRAVIS_BUILD_DIR/*.pretty --table $TRAVIS_BUILD_DIR/fp-lib-table
+


### PR DESCRIPTION
Hi There,

I don't want to cause any conflicts with using kicad-footprints if Travis-Cli is what everyone has chosen to use already. I have seen quite a few projects however move on Debian to salsa.debian.org using Gitlab while still keeping a branch on github and gitlab or in some cases gitlab only. I started to update this project over to using gitlab if this seems an option everyone would like to take however I don't want to create an issue if officially Travis-Cli is what is used. 

There appears to be a project out there already: https://salsa.debian.org/electronics-team/KiCad/kicad-footprints

This portion would mainly update the Repo to allow a Pipeline to run and build just like what Travis-Cli does - there would still need to be some tweaking.

I feel like if this can happen some of the debian developers may have more of a chance pulling into backports more releases being that the code can be pulled into the build server and deployment quicker. Again I am not trying to start an build war but trying to help on some simple updates where I can help out.

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [X] Provide a URL to a datasheet for the footprint(s) you are contributing
- [X] An example screenshot image is very helpful 
- [X] If there are matching symbol or 3D model pull requests, provide link(s) as appropriate
- [X] Check the output of the Travis automated check scripts - fix any errors as required
- [X] Give a reason behind any intentional library convention rule violation.
