### PR TITLE
Remove copper layer from paste (stencil) pads

### DIFF
--- a/Package_TO_SOT_SMD.pretty/Vishay_PowerPAK_SC70-6L_Single.kicad_mod
+++ b/Package_TO_SOT_SMD.pretty/Vishay_PowerPAK_SC70-6L_Single.kicad_mod
@@ -1,4 +1,4 @@
-(module Vishay_PowerPAK_SC70-6L_Single (layer F.Cu) (tedit 5AE7F3BE)
+(module Vishay_PowerPAK_SC70-6L_Single (layer F.Cu) (tedit 5C711CE5)
   (descr "Vishay PowerPAK SC70 single transistor package http://www.vishay.com/docs/70486/70486.pdf")
   (tags "powerpak sc70 sc-70")
   (attr smd)
@@ -31,8 +31,8 @@
   (pad 1 smd rect (at 0.925 -0.65) (size 0.35 0.3) (layers F.Cu F.Paste F.Mask))
   (pad 1 smd rect (at 0 -0.325) (size 1.5 0.95) (layers F.Cu F.Mask))
   (pad 4 smd rect (at 0.04 0.65) (size 0.87 0.235) (layers F.Cu F.Paste F.Mask))
-  (pad "" smd rect (at -0.35 -0.325) (size 0.6 0.8) (layers F.Cu F.Paste))
-  (pad "" smd rect (at 0.35 -0.325) (size 0.6 0.8) (layers F.Cu F.Paste))
+  (pad "" smd rect (at -0.35 -0.325) (size 0.6 0.8) (layers F.Paste))
+  (pad "" smd rect (at 0.35 -0.325) (size 0.6 0.8) (layers F.Paste))
   (model ${KISYS3DMOD}/Package_TO_SOT_SMD.3dshapes/Vishay_PowerPAK_SC70-6L_Single.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))


### PR DESCRIPTION
This PR fixes a bug I found in the Vishay PowerPak Single footprint.

The stencil pads do not have a number (which is correct) but they incorrectly have the front copper layer set. This prevents the footprint from being routed as the copper pads is un-numbered.

For this PR I have simply removed the copper layer.

I think this should be something that the KLC should be able to detect, probably have to implement a collision detection routine for copper shapes.

