### PR TITLE
Transform jumpers into graphical polygons

### DIFF
--- a/Jumper.pretty/SolderJumper-2_P1.3mm_Bridged2Bar_Pad1.0x1.5mm.kicad_mod
+++ b/Jumper.pretty/SolderJumper-2_P1.3mm_Bridged2Bar_Pad1.0x1.5mm.kicad_mod
@@ -1,4 +1,4 @@
-(module SolderJumper-2_P1.3mm_Bridged2Bar_Pad1.0x1.5mm (layer F.Cu) (tedit 5B3911BF)
+(module SolderJumper-2_P1.3mm_Bridged2Bar_Pad1.0x1.5mm (layer F.Cu) (tedit 5C745230)
   (descr "SMD Solder Jumper, 1x1.5mm Pads, 0.3mm gap, bridged with 2 copper strips")
   (tags "solder jumper open")
   (attr virtual)
@@ -16,14 +16,9 @@
   (fp_line (start -1.65 -1.25) (end -1.65 1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 1.65 1.25) (end 1.65 -1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 1.65 1.25) (end -1.65 1.25) (layer F.CrtYd) (width 0.05))
-  (pad 1 smd custom (at -0.65 0) (size 1 1.5) (layers F.Cu F.Mask)
-    (zone_connect 2)
-    (options (clearance outline) (anchor rect))
-    (primitives
-      (gr_poly (pts
-         (xy 0.4 0.2) (xy 0.9 0.2) (xy 0.9 0.6) (xy 0.4 0.6)) (width 0))
-      (gr_poly (pts
-         (xy 0.4 -0.6) (xy 0.9 -0.6) (xy 0.9 -0.2) (xy 0.4 -0.2)) (width 0))
-    ))
+  (fp_poly (pts (xy -0.25 0.2) (xy 0.25 0.2) (xy 0.25 0.6) (xy -0.25 0.6)) (layer F.Cu) (width 0))
+  (fp_poly (pts (xy -0.25 -0.6) (xy 0.25 -0.6) (xy 0.25 -0.2) (xy -0.25 -0.2)) (layer F.Cu) (width 0))
+  (pad 1 smd rect (at -0.65 0) (size 1 1.5) (layers F.Cu F.Mask)
+    (zone_connect 2))
   (pad 2 smd rect (at 0.65 0) (size 1 1.5) (layers F.Cu F.Mask))
 )

--- a/Jumper.pretty/SolderJumper-2_P1.3mm_Bridged2Bar_RoundedPad1.0x1.5mm.kicad_mod
+++ b/Jumper.pretty/SolderJumper-2_P1.3mm_Bridged2Bar_RoundedPad1.0x1.5mm.kicad_mod
@@ -1,4 +1,4 @@
-(module SolderJumper-2_P1.3mm_Bridged2Bar_RoundedPad1.0x1.5mm (layer F.Cu) (tedit 5B3916F8)
+(module SolderJumper-2_P1.3mm_Bridged2Bar_RoundedPad1.0x1.5mm (layer F.Cu) (tedit 5C74525F)
   (descr "SMD Solder Jumper, 1x1.5mm, rounded Pads, 0.3mm gap, bridged with 2 copper strips")
   (tags "solder jumper open")
   (attr virtual)
@@ -20,19 +20,8 @@
   (fp_line (start -1.65 -1.25) (end -1.65 1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 1.65 1.25) (end 1.65 -1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 1.65 1.25) (end -1.65 1.25) (layer F.CrtYd) (width 0.05))
-  (pad 1 smd custom (at -0.65 0) (size 1 0.5) (layers F.Cu F.Mask)
-    (zone_connect 2)
-    (options (clearance outline) (anchor rect))
-    (primitives
-      (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
-      (gr_circle (center 0 -0.25) (end 0.5 -0.25) (width 0))
-      (gr_poly (pts
-         (xy 0.5 0.75) (xy 0.5 -0.75) (xy 0 -0.75) (xy 0 0.75)) (width 0))
-      (gr_poly (pts
-         (xy 0.4 0.2) (xy 0.9 0.2) (xy 0.9 0.6) (xy 0.4 0.6)) (width 0))
-      (gr_poly (pts
-         (xy 0.4 -0.6) (xy 0.9 -0.6) (xy 0.9 -0.2) (xy 0.4 -0.2)) (width 0))
-    ))
+  (fp_poly (pts (xy -0.25 0.2) (xy 0.25 0.2) (xy 0.25 0.6) (xy -0.25 0.6)) (layer F.Cu) (width 0))
+  (fp_poly (pts (xy -0.25 -0.6) (xy 0.25 -0.6) (xy 0.25 -0.2) (xy -0.25 -0.2)) (layer F.Cu) (width 0))
   (pad 2 smd custom (at 0.65 0) (size 1 0.5) (layers F.Cu F.Mask)
     (zone_connect 2)
     (options (clearance outline) (anchor rect))
@@ -41,5 +30,14 @@
       (gr_circle (center 0 -0.25) (end 0.5 -0.25) (width 0))
       (gr_poly (pts
          (xy -0.5 0.75) (xy -0.5 -0.75) (xy 0 -0.75) (xy 0 0.75)) (width 0))
+    ))
+  (pad 1 smd custom (at -0.65 0) (size 1 0.5) (layers F.Cu F.Mask)
+    (zone_connect 2)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
+      (gr_circle (center 0 -0.25) (end 0.5 -0.25) (width 0))
+      (gr_poly (pts
+         (xy 0.5 0.75) (xy 0.5 -0.75) (xy 0 -0.75) (xy 0 0.75)) (width 0))
     ))
 )

--- a/Jumper.pretty/SolderJumper-2_P1.3mm_Bridged_Pad1.0x1.5mm.kicad_mod
+++ b/Jumper.pretty/SolderJumper-2_P1.3mm_Bridged_Pad1.0x1.5mm.kicad_mod
@@ -1,4 +1,4 @@
-(module SolderJumper-2_P1.3mm_Bridged_Pad1.0x1.5mm (layer F.Cu) (tedit 5B391424)
+(module SolderJumper-2_P1.3mm_Bridged_Pad1.0x1.5mm (layer F.Cu) (tedit 5C74526E)
   (descr "SMD Solder Jumper, 1x1.5mm Pads, 0.3mm gap, bridged with 1 copper strip")
   (tags "solder jumper open")
   (attr virtual)
@@ -16,12 +16,8 @@
   (fp_line (start -1.65 -1.25) (end -1.65 1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 1.65 1.25) (end 1.65 -1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 1.65 1.25) (end -1.65 1.25) (layer F.CrtYd) (width 0.05))
-  (pad 1 smd custom (at -0.65 0) (size 1 1.5) (layers F.Cu F.Mask)
-    (zone_connect 2)
-    (options (clearance outline) (anchor rect))
-    (primitives
-      (gr_poly (pts
-         (xy 0.4 -0.3) (xy 0.9 -0.3) (xy 0.9 0.3) (xy 0.4 0.3)) (width 0))
-    ))
+  (fp_poly (pts (xy -0.25 -0.3) (xy 0.25 -0.3) (xy 0.25 0.3) (xy -0.25 0.3)) (layer F.Cu) (width 0))
+  (pad 1 smd rect (at -0.65 0) (size 1 1.5) (layers F.Cu F.Mask)
+    (zone_connect 2))
   (pad 2 smd rect (at 0.65 0) (size 1 1.5) (layers F.Cu F.Mask))
 )

--- a/Jumper.pretty/SolderJumper-2_P1.3mm_Bridged_RoundedPad1.0x1.5mm.kicad_mod
+++ b/Jumper.pretty/SolderJumper-2_P1.3mm_Bridged_RoundedPad1.0x1.5mm.kicad_mod
@@ -1,4 +1,4 @@
-(module SolderJumper-2_P1.3mm_Bridged_RoundedPad1.0x1.5mm (layer F.Cu) (tedit 5B391ABA)
+(module SolderJumper-2_P1.3mm_Bridged_RoundedPad1.0x1.5mm (layer F.Cu) (tedit 5C745284)
   (descr "SMD Solder Jumper, 1x1.5mm, rounded Pads, 0.3mm gap, bridged with 1 copper strip")
   (tags "solder jumper open")
   (attr virtual)
@@ -20,17 +20,7 @@
   (fp_line (start -1.65 -1.25) (end -1.65 1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 1.65 1.25) (end 1.65 -1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 1.65 1.25) (end -1.65 1.25) (layer F.CrtYd) (width 0.05))
-  (pad 1 smd custom (at -0.65 0) (size 1 0.5) (layers F.Cu F.Mask)
-    (zone_connect 2)
-    (options (clearance outline) (anchor rect))
-    (primitives
-      (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
-      (gr_circle (center 0 -0.25) (end 0.5 -0.25) (width 0))
-      (gr_poly (pts
-         (xy 0 -0.75) (xy 0.5 -0.75) (xy 0.5 0.75) (xy 0 0.75)) (width 0))
-      (gr_poly (pts
-         (xy 0.9 -0.3) (xy 0.4 -0.3) (xy 0.4 0.3) (xy 0.9 0.3)) (width 0))
-    ))
+  (fp_poly (pts (xy 0.25 -0.3) (xy -0.25 -0.3) (xy -0.25 0.3) (xy 0.25 0.3)) (layer F.Cu) (width 0))
   (pad 2 smd custom (at 0.65 0) (size 1 0.5) (layers F.Cu F.Mask)
     (zone_connect 2)
     (options (clearance outline) (anchor rect))
@@ -39,5 +29,14 @@
       (gr_circle (center 0 -0.25) (end 0.5 -0.25) (width 0))
       (gr_poly (pts
          (xy 0 -0.75) (xy -0.5 -0.75) (xy -0.5 0.75) (xy 0 0.75)) (width 0))
+    ))
+  (pad 1 smd custom (at -0.65 0) (size 1 0.5) (layers F.Cu F.Mask)
+    (zone_connect 2)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
+      (gr_circle (center 0 -0.25) (end 0.5 -0.25) (width 0))
+      (gr_poly (pts
+         (xy 0 -0.75) (xy 0.5 -0.75) (xy 0.5 0.75) (xy 0 0.75)) (width 0))
     ))
 )

--- a/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged12_Pad1.0x1.5mm.kicad_mod
+++ b/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged12_Pad1.0x1.5mm.kicad_mod
@@ -1,4 +1,4 @@
-(module SolderJumper-3_P1.3mm_Bridged12_Pad1.0x1.5mm (layer F.Cu) (tedit 5B3914C4)
+(module SolderJumper-3_P1.3mm_Bridged12_Pad1.0x1.5mm (layer F.Cu) (tedit 5C7452F1)
   (descr "SMD Solder 3-pad Jumper, 1x1.5mm Pads, 0.3mm gap, pads 1-2 bridged with 1 copper strip")
   (tags "solder jumper open")
   (attr virtual)
@@ -19,13 +19,9 @@
   (fp_line (start -2.3 -1.25) (end -2.3 1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 2.3 1.25) (end 2.3 -1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 2.3 1.25) (end -2.3 1.25) (layer F.CrtYd) (width 0.05))
-  (pad 1 smd custom (at -1.3 0) (size 1 1.5) (layers F.Cu F.Mask)
-    (zone_connect 2)
-    (options (clearance outline) (anchor rect))
-    (primitives
-      (gr_poly (pts
-         (xy 0.4 -0.3) (xy 0.9 -0.3) (xy 0.9 0.3) (xy 0.4 0.3)) (width 0))
-    ))
+  (fp_poly (pts (xy -0.9 -0.3) (xy -0.4 -0.3) (xy -0.4 0.3) (xy -0.9 0.3)) (layer F.Cu) (width 0))
+  (pad 1 smd rect (at -1.3 0) (size 1 1.5) (layers F.Cu F.Mask)
+    (zone_connect 2))
   (pad 3 smd rect (at 1.3 0) (size 1 1.5) (layers F.Cu F.Mask))
   (pad 2 smd rect (at 0 0) (size 1 1.5) (layers F.Cu F.Mask))
 )

--- a/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged12_Pad1.0x1.5mm_NumberLabels.kicad_mod
+++ b/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged12_Pad1.0x1.5mm_NumberLabels.kicad_mod
@@ -1,4 +1,4 @@
-(module SolderJumper-3_P1.3mm_Bridged12_Pad1.0x1.5mm_NumberLabels (layer F.Cu) (tedit 5B3914E1)
+(module SolderJumper-3_P1.3mm_Bridged12_Pad1.0x1.5mm_NumberLabels (layer F.Cu) (tedit 5C745310)
   (descr "SMD Solder Jumper, 1x1.5mm Pads, 0.3mm gap, pads 1-2 bridged with 1 copper strip, labeled with numbers")
   (tags "solder jumper open")
   (attr virtual)
@@ -22,13 +22,9 @@
   (fp_line (start -2.3 -1.25) (end -2.3 1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 2.3 1.25) (end 2.3 -1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 2.3 1.25) (end -2.3 1.25) (layer F.CrtYd) (width 0.05))
-  (pad 1 smd custom (at -1.3 0) (size 1 1.5) (layers F.Cu F.Mask)
-    (zone_connect 2)
-    (options (clearance outline) (anchor rect))
-    (primitives
-      (gr_poly (pts
-         (xy 0.4 -0.3) (xy 0.9 -0.3) (xy 0.9 0.3) (xy 0.4 0.3)) (width 0))
-    ))
+  (fp_poly (pts (xy -0.9 -0.3) (xy -0.4 -0.3) (xy -0.4 0.3) (xy -0.9 0.3)) (layer F.Cu) (width 0))
+  (pad 1 smd rect (at -1.3 0) (size 1 1.5) (layers F.Cu F.Mask)
+    (zone_connect 2))
   (pad 3 smd rect (at 1.3 0) (size 1 1.5) (layers F.Cu F.Mask))
   (pad 2 smd rect (at 0 0) (size 1 1.5) (layers F.Cu F.Mask))
 )

--- a/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged12_RoundedPad1.0x1.5mm.kicad_mod
+++ b/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged12_RoundedPad1.0x1.5mm.kicad_mod
@@ -1,4 +1,4 @@
-(module SolderJumper-3_P1.3mm_Bridged12_RoundedPad1.0x1.5mm (layer F.Cu) (tedit 5B391DE3)
+(module SolderJumper-3_P1.3mm_Bridged12_RoundedPad1.0x1.5mm (layer F.Cu) (tedit 5C745321)
   (descr "SMD Solder 3-pad Jumper, 1x1.5mm rounded Pads, 0.3mm gap, pads 1-2 bridged with 1 copper strip")
   (tags "solder jumper open")
   (attr virtual)
@@ -23,17 +23,7 @@
   (fp_arc (start 1.35 0.3) (end 1.35 1) (angle -90) (layer F.SilkS) (width 0.12))
   (fp_arc (start -1.35 0.3) (end -2.05 0.3) (angle -90) (layer F.SilkS) (width 0.12))
   (fp_arc (start -1.35 -0.3) (end -1.35 -1) (angle -90) (layer F.SilkS) (width 0.12))
-  (pad 1 smd custom (at -1.3 0) (size 1 0.5) (layers F.Cu F.Mask)
-    (zone_connect 2)
-    (options (clearance outline) (anchor rect))
-    (primitives
-      (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
-      (gr_circle (center 0 -0.25) (end 0.5 -0.25) (width 0))
-      (gr_poly (pts
-         (xy 0.55 -0.75) (xy 0 -0.75) (xy 0 0.75) (xy 0.55 0.75)) (width 0))
-      (gr_poly (pts
-         (xy 0.4 -0.3) (xy 0.9 -0.3) (xy 0.9 0.3) (xy 0.4 0.3)) (width 0))
-    ))
+  (fp_poly (pts (xy -0.9 -0.3) (xy -0.4 -0.3) (xy -0.4 0.3) (xy -0.9 0.3)) (layer F.Cu) (width 0))
   (pad 3 smd custom (at 1.3 0) (size 1 0.5) (layers F.Cu F.Mask)
     (zone_connect 2)
     (options (clearance outline) (anchor rect))
@@ -44,4 +34,13 @@
          (xy -0.55 -0.75) (xy 0 -0.75) (xy 0 0.75) (xy -0.55 0.75)) (width 0))
     ))
   (pad 2 smd rect (at 0 0) (size 1 1.5) (layers F.Cu F.Mask))
+  (pad 1 smd custom (at -1.3 0) (size 1 0.5) (layers F.Cu F.Mask)
+    (zone_connect 2)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
+      (gr_circle (center 0 -0.25) (end 0.5 -0.25) (width 0))
+      (gr_poly (pts
+         (xy 0.55 -0.75) (xy 0 -0.75) (xy 0 0.75) (xy 0.55 0.75)) (width 0))
+    ))
 )

--- a/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged12_RoundedPad1.0x1.5mm_NumberLabels.kicad_mod
+++ b/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged12_RoundedPad1.0x1.5mm_NumberLabels.kicad_mod
@@ -1,4 +1,4 @@
-(module SolderJumper-3_P1.3mm_Bridged12_RoundedPad1.0x1.5mm_NumberLabels (layer F.Cu) (tedit 5B391DD7)
+(module SolderJumper-3_P1.3mm_Bridged12_RoundedPad1.0x1.5mm_NumberLabels (layer F.Cu) (tedit 5C745336)
   (descr "SMD Solder 3-pad Jumper, 1x1.5mm rounded Pads, 0.3mm gap, pads 1-2 bridged with 1 copper strip, labeled with numbers")
   (tags "solder jumper open")
   (attr virtual)
@@ -26,17 +26,7 @@
   (fp_arc (start 1.35 0.3) (end 1.35 1) (angle -90) (layer F.SilkS) (width 0.12))
   (fp_arc (start -1.35 0.3) (end -2.05 0.3) (angle -90) (layer F.SilkS) (width 0.12))
   (fp_arc (start -1.35 -0.3) (end -1.35 -1) (angle -90) (layer F.SilkS) (width 0.12))
-  (pad 1 smd custom (at -1.3 0) (size 1 0.5) (layers F.Cu F.Mask)
-    (zone_connect 2)
-    (options (clearance outline) (anchor rect))
-    (primitives
-      (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
-      (gr_circle (center 0 -0.25) (end 0.5 -0.25) (width 0))
-      (gr_poly (pts
-         (xy 0.55 -0.75) (xy 0 -0.75) (xy 0 0.75) (xy 0.55 0.75)) (width 0))
-      (gr_poly (pts
-         (xy 0.4 -0.3) (xy 0.9 -0.3) (xy 0.9 0.3) (xy 0.4 0.3)) (width 0))
-    ))
+  (fp_poly (pts (xy -0.9 -0.3) (xy -0.4 -0.3) (xy -0.4 0.3) (xy -0.9 0.3)) (layer F.Cu) (width 0))
   (pad 3 smd custom (at 1.3 0) (size 1 0.5) (layers F.Cu F.Mask)
     (zone_connect 2)
     (options (clearance outline) (anchor rect))
@@ -47,4 +37,13 @@
          (xy -0.55 -0.75) (xy 0 -0.75) (xy 0 0.75) (xy -0.55 0.75)) (width 0))
     ))
   (pad 2 smd rect (at 0 0) (size 1 1.5) (layers F.Cu F.Mask))
+  (pad 1 smd custom (at -1.3 0) (size 1 0.5) (layers F.Cu F.Mask)
+    (zone_connect 2)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_poly (pts
+         (xy 0.55 -0.75) (xy 0 -0.75) (xy 0 0.75) (xy 0.55 0.75)) (width 0))
+      (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
+      (gr_circle (center 0 -0.25) (end 0.5 -0.25) (width 0))
+    ))
 )

--- a/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged2Bar12_Pad1.0x1.5mm.kicad_mod
+++ b/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged2Bar12_Pad1.0x1.5mm.kicad_mod
@@ -1,4 +1,4 @@
-(module SolderJumper-3_P1.3mm_Bridged2Bar12_Pad1.0x1.5mm (layer F.Cu) (tedit 5B391491)
+(module SolderJumper-3_P1.3mm_Bridged2Bar12_Pad1.0x1.5mm (layer F.Cu) (tedit 5C74529C)
   (descr "SMD Solder 3-pad Jumper, 1x1.5mm Pads, 0.3mm gap, pads 1-2 Bridged2Bar with 2 copper strip")
   (tags "solder jumper open")
   (attr virtual)
@@ -19,15 +19,10 @@
   (fp_line (start -2.3 -1.25) (end -2.3 1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 2.3 1.25) (end 2.3 -1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 2.3 1.25) (end -2.3 1.25) (layer F.CrtYd) (width 0.05))
-  (pad 1 smd custom (at -1.3 0) (size 1 1.5) (layers F.Cu F.Mask)
-    (zone_connect 2)
-    (options (clearance outline) (anchor rect))
-    (primitives
-      (gr_poly (pts
-         (xy 0.4 -0.6) (xy 0.9 -0.6) (xy 0.9 -0.2) (xy 0.4 -0.2)) (width 0))
-      (gr_poly (pts
-         (xy 0.4 0.2) (xy 0.9 0.2) (xy 0.9 0.6) (xy 0.4 0.6)) (width 0))
-    ))
+  (fp_poly (pts (xy -0.9 -0.6) (xy -0.4 -0.6) (xy -0.4 -0.2) (xy -0.9 -0.2)) (layer F.Cu) (width 0))
+  (fp_poly (pts (xy -0.9 0.2) (xy -0.4 0.2) (xy -0.4 0.6) (xy -0.9 0.6)) (layer F.Cu) (width 0))
+  (pad 1 smd rect (at -1.3 0) (size 1 1.5) (layers F.Cu F.Mask)
+    (zone_connect 2))
   (pad 3 smd rect (at 1.3 0) (size 1 1.5) (layers F.Cu F.Mask))
   (pad 2 smd rect (at 0 0) (size 1 1.5) (layers F.Cu F.Mask))
 )

--- a/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged2Bar12_Pad1.0x1.5mm_NumberLabels.kicad_mod
+++ b/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged2Bar12_Pad1.0x1.5mm_NumberLabels.kicad_mod
@@ -1,4 +1,4 @@
-(module SolderJumper-3_P1.3mm_Bridged2Bar12_Pad1.0x1.5mm_NumberLabels (layer F.Cu) (tedit 5B39184F)
+(module SolderJumper-3_P1.3mm_Bridged2Bar12_Pad1.0x1.5mm_NumberLabels (layer F.Cu) (tedit 5C7452AC)
   (descr "SMD Solder Jumper, 1x1.5mm Pads, 0.3mm gap, pads 1-2 Bridged2Bar with 2 copper strip, labeled with numbers")
   (tags "solder jumper open")
   (attr virtual)
@@ -22,15 +22,10 @@
   (fp_line (start -2.3 -1.25) (end -2.3 1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 2.3 1.25) (end 2.3 -1.25) (layer F.CrtYd) (width 0.05))
   (fp_line (start 2.3 1.25) (end -2.3 1.25) (layer F.CrtYd) (width 0.05))
-  (pad 1 smd custom (at -1.3 0) (size 1 1.5) (layers F.Cu F.Mask)
-    (zone_connect 2)
-    (options (clearance outline) (anchor rect))
-    (primitives
-      (gr_poly (pts
-         (xy 0.4 0.2) (xy 0.9 0.2) (xy 0.9 0.6) (xy 0.4 0.6)) (width 0))
-      (gr_poly (pts
-         (xy 0.4 -0.6) (xy 0.9 -0.6) (xy 0.9 -0.2) (xy 0.4 -0.2)) (width 0))
-    ))
+  (fp_poly (pts (xy -0.9 0.2) (xy -0.4 0.2) (xy -0.4 0.6) (xy -0.9 0.6)) (layer F.Cu) (width 0))
+  (fp_poly (pts (xy -0.9 -0.6) (xy -0.4 -0.6) (xy -0.4 -0.2) (xy -0.9 -0.2)) (layer F.Cu) (width 0))
+  (pad 1 smd rect (at -1.3 0) (size 1 1.5) (layers F.Cu F.Mask)
+    (zone_connect 2))
   (pad 3 smd rect (at 1.3 0) (size 1 1.5) (layers F.Cu F.Mask))
   (pad 2 smd rect (at 0 0) (size 1 1.5) (layers F.Cu F.Mask))
 )

--- a/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged2Bar12_RoundedPad1.0x1.5mm.kicad_mod
+++ b/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged2Bar12_RoundedPad1.0x1.5mm.kicad_mod
@@ -1,4 +1,4 @@
-(module SolderJumper-3_P1.3mm_Bridged2Bar12_RoundedPad1.0x1.5mm (layer F.Cu) (tedit 5B39197B)
+(module SolderJumper-3_P1.3mm_Bridged2Bar12_RoundedPad1.0x1.5mm (layer F.Cu) (tedit 5C7452C1)
   (descr "SMD Solder 3-pad Jumper, 1x1.5mm rounded Pads, 0.3mm gap, pads 1-2 Bridged2Bar with 2 copper strip")
   (tags "solder jumper open")
   (attr virtual)
@@ -23,19 +23,8 @@
   (fp_arc (start 1.35 0.3) (end 1.35 1) (angle -90) (layer F.SilkS) (width 0.12))
   (fp_arc (start -1.35 0.3) (end -2.05 0.3) (angle -90) (layer F.SilkS) (width 0.12))
   (fp_arc (start -1.35 -0.3) (end -1.35 -1) (angle -90) (layer F.SilkS) (width 0.12))
-  (pad 1 smd custom (at -1.3 0) (size 1 0.5) (layers F.Cu F.Mask)
-    (zone_connect 2)
-    (options (clearance outline) (anchor rect))
-    (primitives
-      (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
-      (gr_circle (center 0 -0.25) (end 0.5 -0.25) (width 0))
-      (gr_poly (pts
-         (xy 0.55 -0.75) (xy 0 -0.75) (xy 0 0.75) (xy 0.55 0.75)) (width 0))
-      (gr_poly (pts
-         (xy 0.4 -0.6) (xy 0.9 -0.6) (xy 0.9 -0.2) (xy 0.4 -0.2)) (width 0))
-      (gr_poly (pts
-         (xy 0.4 0.2) (xy 0.9 0.2) (xy 0.9 0.6) (xy 0.4 0.6)) (width 0))
-    ))
+  (fp_poly (pts (xy -0.9 -0.6) (xy -0.4 -0.6) (xy -0.4 -0.2) (xy -0.9 -0.2)) (layer F.Cu) (width 0))
+  (fp_poly (pts (xy -0.9 0.2) (xy -0.4 0.2) (xy -0.4 0.6) (xy -0.9 0.6)) (layer F.Cu) (width 0))
   (pad 3 smd custom (at 1.3 0) (size 1 0.5) (layers F.Cu F.Mask)
     (zone_connect 2)
     (options (clearance outline) (anchor rect))
@@ -46,4 +35,13 @@
          (xy -0.55 -0.75) (xy 0 -0.75) (xy 0 0.75) (xy -0.55 0.75)) (width 0))
     ))
   (pad 2 smd rect (at 0 0) (size 1 1.5) (layers F.Cu F.Mask))
+  (pad 1 smd custom (at -1.3 0) (size 1 0.5) (layers F.Cu F.Mask)
+    (zone_connect 2)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
+      (gr_circle (center 0 -0.25) (end 0.5 -0.25) (width 0))
+      (gr_poly (pts
+         (xy 0.55 -0.75) (xy 0 -0.75) (xy 0 0.75) (xy 0.55 0.75)) (width 0))
+    ))
 )

--- a/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged2Bar12_RoundedPad1.0x1.5mm_NumberLabels.kicad_mod
+++ b/Jumper.pretty/SolderJumper-3_P1.3mm_Bridged2Bar12_RoundedPad1.0x1.5mm_NumberLabels.kicad_mod
@@ -1,4 +1,4 @@
-(module SolderJumper-3_P1.3mm_Bridged2Bar12_RoundedPad1.0x1.5mm_NumberLabels (layer F.Cu) (tedit 5B391A16)
+(module SolderJumper-3_P1.3mm_Bridged2Bar12_RoundedPad1.0x1.5mm_NumberLabels (layer F.Cu) (tedit 5C7452E6)
   (descr "SMD Solder 3-pad Jumper, 1x1.5mm rounded Pads, 0.3mm gap, pads 1-2 Bridged2Bar with 2 copper strip, labeled with numbers")
   (tags "solder jumper open")
   (attr virtual)
@@ -26,19 +26,8 @@
   (fp_arc (start 1.35 0.3) (end 1.35 1) (angle -90) (layer F.SilkS) (width 0.12))
   (fp_arc (start -1.35 0.3) (end -2.05 0.3) (angle -90) (layer F.SilkS) (width 0.12))
   (fp_arc (start -1.35 -0.3) (end -1.35 -1) (angle -90) (layer F.SilkS) (width 0.12))
-  (pad 1 smd custom (at -1.3 0) (size 1 0.5) (layers F.Cu F.Mask)
-    (zone_connect 2)
-    (options (clearance outline) (anchor rect))
-    (primitives
-      (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
-      (gr_circle (center 0 -0.25) (end 0.5 -0.25) (width 0))
-      (gr_poly (pts
-         (xy 0.55 -0.75) (xy 0 -0.75) (xy 0 0.75) (xy 0.55 0.75)) (width 0))
-      (gr_poly (pts
-         (xy 0.4 -0.6) (xy 0.9 -0.6) (xy 0.9 -0.2) (xy 0.4 -0.2)) (width 0))
-      (gr_poly (pts
-         (xy 0.4 0.2) (xy 0.9 0.2) (xy 0.9 0.6) (xy 0.4 0.6)) (width 0))
-    ))
+  (fp_poly (pts (xy -0.9 -0.6) (xy -0.4 -0.6) (xy -0.4 -0.2) (xy -0.9 -0.2)) (layer F.Cu) (width 0))
+  (fp_poly (pts (xy -0.9 0.2) (xy -0.4 0.2) (xy -0.4 0.6) (xy -0.9 0.6)) (layer F.Cu) (width 0))
   (pad 3 smd custom (at 1.3 0) (size 1 0.5) (layers F.Cu F.Mask)
     (zone_connect 2)
     (options (clearance outline) (anchor rect))
@@ -49,4 +38,13 @@
          (xy -0.55 -0.75) (xy 0 -0.75) (xy 0 0.75) (xy -0.55 0.75)) (width 0))
     ))
   (pad 2 smd rect (at 0 0) (size 1 1.5) (layers F.Cu F.Mask))
+  (pad 1 smd custom (at -1.3 0) (size 1 0.5) (layers F.Cu F.Mask)
+    (zone_connect 2)
+    (options (clearance outline) (anchor rect))
+    (primitives
+      (gr_circle (center 0 0.25) (end 0.5 0.25) (width 0))
+      (gr_circle (center 0 -0.25) (end 0.5 -0.25) (width 0))
+      (gr_poly (pts
+         (xy 0.55 -0.75) (xy 0 -0.75) (xy 0 0.75) (xy 0.55 0.75)) (width 0))
+    ))
 )


### PR DESCRIPTION
DRC is not yet smart enough to distinguish jumpered pads when they
touch, so we work around this for 5.1 by using graphical polygons on the
F.Cu layer.

This separates the jumpered pads into pads and connecting polygons.  This formulation allows DRC checks to pass and routing to happen on both pads without requiring DRC errors allowed.

This does not change the pad shape or size for the affected footprints.
![bildschirmfoto_2019-02-25_12-57-55](https://user-images.githubusercontent.com/914826/53368378-71e19000-38fd-11e9-8565-31b52d32d05c.png)
![bildschirmfoto_2019-02-25_12-57-41](https://user-images.githubusercontent.com/914826/53368379-71e19000-38fd-11e9-9477-a76348bebe21.png)
![bildschirmfoto_2019-02-25_12-57-29](https://user-images.githubusercontent.com/914826/53368380-71e19000-38fd-11e9-8015-44459a0b0c7d.png)
![bildschirmfoto_2019-02-25_12-57-13](https://user-images.githubusercontent.com/914826/53368381-727a2680-38fd-11e9-99f1-08867f3bb5aa.png)
![bildschirmfoto_2019-02-25_12-56-48](https://user-images.githubusercontent.com/914826/53368383-727a2680-38fd-11e9-8ef3-3cd345491ef1.png)

---

All contributions to the kicad library must follow the [KiCad library convention](http://kicad-pcb.org/libraries/klc/)

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the footprint(s) you are contributing
- [ ] An example screenshot image is very helpful 
- [ ] If there are matching symbol or 3D model pull requests, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
- [ ] Give a reason behind any intentional library convention rule violation.
