### PR TITLE
Package_SO: Rename SOIJ-8_5.3x5.3mm_P1.27mm to SOIC-8W_5.3x5.3mm_P1.27mm

### DIFF
--- a/Package_SO.pretty/SOIC-8W_5.3x5.3mm_P1.27mm.kicad_mod
+++ b/Package_SO.pretty/SOIC-8W_5.3x5.3mm_P1.27mm.kicad_mod
@@ -1,11 +1,11 @@
-(module SOIJ-8_5.3x5.3mm_P1.27mm (layer F.Cu) (tedit 5A02F2D3)
-  (descr "8-Lead Plastic Small Outline (SM) - Medium, 5.28 mm Body [SOIC] (see Microchip Packaging Specification 00000049BS.pdf)")
+(module SOIC-8W_5.3x5.3mm_P1.27mm (layer F.Cu) (tedit 5A02F2D3)
+  (descr "8-Lead Plastic Small Outline (SM) - 5.28 mm Body [SOIC] (http://ww1.microchip.com/downloads/en/PackagingSpec/00000049BQ.pdf)")
   (tags "SOIC 1.27")
   (attr smd)
   (fp_text reference REF** (at 0 -3.68) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (fp_text value SOIJ-8_5.3x5.3mm_P1.27mm (at 0 3.68) (layer F.Fab)
+  (fp_text value SOIC-8W_5.3x5.3mm_P1.27mm (at 0 3.68) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
   (fp_text user %R (at 0 0) (layer F.Fab)
@@ -35,7 +35,7 @@
   (pad 6 smd rect (at 3.65 0.635) (size 1.7 0.65) (layers F.Cu F.Paste F.Mask))
   (pad 7 smd rect (at 3.65 -0.635) (size 1.7 0.65) (layers F.Cu F.Paste F.Mask))
   (pad 8 smd rect (at 3.65 -1.905) (size 1.7 0.65) (layers F.Cu F.Paste F.Mask))
-  (model ${KISYS3DMOD}/Package_SO.3dshapes/SOIJ-8_5.3x5.3mm_P1.27mm.wrl
+  (model ${KISYS3DMOD}/Package_SO.3dshapes/SOIC-8W_5.3x5.3mm_P1.27mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))


### PR DESCRIPTION
The SOIJ-8 package name is only used by the package specification
documents by Microchip. Other manufacturers usually just call it a
variant of SOIC/SOP with 208mil (5.28mm) body. This package is currently
modern among 25 SPI Flash chips from many manufacturers, including
Winbond, GigaDevice, Micron, ST, etc.

As the SOIJ-8 name is vendor specific, and will mislead people with the
"J" as J lead, rename it to SOIC-8W, meaning a wider version of SOIC-8.

Signed-off-by: Icenowy Zheng <icenowy@aosc.io>