### PR TITLE
Vishay_PowerPAK_1212-8 custom pad zone connection to Solid

### DIFF
--- a/Package_SO.pretty/Vishay_PowerPAK_1212-8_Dual.kicad_mod
+++ b/Package_SO.pretty/Vishay_PowerPAK_1212-8_Dual.kicad_mod
@@ -30,7 +30,7 @@
   (pad 3 smd rect (at -1.435 0.33) (size 0.99 0.405) (layers F.Cu F.Paste F.Mask))
   (pad 4 smd rect (at -1.435 0.99) (size 0.99 0.405) (layers F.Cu F.Paste F.Mask))
   (pad 5 smd custom (at 0.5575 0.6075) (size 1.725 0.99) (layers F.Cu F.Paste F.Mask)
-    (zone_connect 0)
+    (zone_connect 2)
     (options (clearance outline) (anchor rect))
     (primitives
       (gr_poly (pts
@@ -38,7 +38,7 @@
          (xy 1.3725 0.165) (xy 1.3725 0.5875) (xy 0.6125 0.5875)) (width 0))
     ))
   (pad 6 smd custom (at 0.5575 -0.6075) (size 1.725 0.99) (layers F.Cu F.Paste F.Mask)
-    (zone_connect 0)
+    (zone_connect 2)
     (options (clearance outline) (anchor rect))
     (primitives
       (gr_poly (pts

--- a/Package_SO.pretty/Vishay_PowerPAK_1212-8_Single.kicad_mod
+++ b/Package_SO.pretty/Vishay_PowerPAK_1212-8_Single.kicad_mod
@@ -30,7 +30,7 @@
   (pad 3 smd rect (at -1.435 0.33) (size 0.99 0.405) (layers F.Cu F.Paste F.Mask))
   (pad 4 smd rect (at -1.435 0.99) (size 0.99 0.405) (layers F.Cu F.Paste F.Mask))
   (pad 5 smd custom (at 0.5575 0) (size 1.725 2.235) (layers F.Cu F.Paste F.Mask)
-    (zone_connect 0)
+    (zone_connect 2)
     (options (clearance outline) (anchor rect))
     (primitives
       (gr_poly (pts


### PR DESCRIPTION
Address a couple footprints not in https://github.com/KiCad/kicad-footprints/pull/981 that were reported at https://github.com/pointhi/kicad-footprint-generator/issues/308. Changes their zone connection from None to Solid to the custom pads will connect to zones.

---

All contributions to the kicad library must follow the [KiCad library convention](http://kicad-pcb.org/libraries/klc/)

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the footprint(s) you are contributing
- [ ] An example screenshot image is very helpful 
- [ ] If there are matching symbol or 3D model pull requests, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
- [ ] Give a reason behind any intentional library convention rule violation.
