### PR TITLE
Add WQFN-20-1EP_4x4mm_P0.5mm_EP2.7x2.7mm_ThermalVias

### DIFF
--- a/Package_DFN_QFN.pretty/WQFN-20-1EP_4x4mm_P0.5mm_EP2.7x2.7mm_ThermalVias.kicad_mod
+++ b/Package_DFN_QFN.pretty/WQFN-20-1EP_4x4mm_P0.5mm_EP2.7x2.7mm_ThermalVias.kicad_mod
@@ -1,0 +1,189 @@
+(module WQFN-20-1EP_4x4mm_P0.5mm_EP2.7x2.7mm_ThermalVias (layer F.Cu) (tedit 5C83978D)
+  (descr http://www.ti.com/lit/ds/symlink/tpa6130a2.pdf)
+  (tags WQFN)
+  (attr smd)
+  (fp_text reference REF** (at 0 -3.4) (layer F.SilkS)
+    (effects (font (size 1 1) (thickness 0.15)))
+  )
+  (fp_text value WQFN-20-1EP_4x4mm_P0.5mm_EP2.7x2.7mm_ThermalVias (at 0 3.3) (layer F.Fab)
+    (effects (font (size 1 1) (thickness 0.15)))
+  )
+  (fp_line (start -1 -2) (end 2 -2) (layer F.Fab) (width 0.1))
+  (fp_line (start 2 -2) (end 2 2) (layer F.Fab) (width 0.1))
+  (fp_line (start 2 2) (end -2 2) (layer F.Fab) (width 0.1))
+  (fp_line (start -2 2) (end -2 -1) (layer F.Fab) (width 0.1))
+  (fp_line (start -2.65 -2.65) (end 2.65 -2.65) (layer F.CrtYd) (width 0.05))
+  (fp_line (start 2.65 -2.65) (end 2.65 2.65) (layer F.CrtYd) (width 0.05))
+  (fp_line (start 2.65 2.65) (end -2.65 2.65) (layer F.CrtYd) (width 0.05))
+  (fp_line (start -2.65 2.65) (end -2.65 -2.65) (layer F.CrtYd) (width 0.05))
+  (fp_line (start -1 -2) (end -2 -1) (layer F.Fab) (width 0.1))
+  (fp_text user %R (at 0 0) (layer F.Fab)
+    (effects (font (size 0.8 0.8) (thickness 0.12)))
+  )
+  (fp_line (start 1.65 2.2) (end 2.2 2.2) (layer F.SilkS) (width 0.12))
+  (fp_line (start 2.2 2.2) (end 2.2 1.65) (layer F.SilkS) (width 0.12))
+  (fp_line (start 2.2 -1.65) (end 2.2 -2.2) (layer F.SilkS) (width 0.12))
+  (fp_line (start 2.2 -2.2) (end 1.65 -2.2) (layer F.SilkS) (width 0.12))
+  (fp_line (start -2.2 1.65) (end -2.2 2.2) (layer F.SilkS) (width 0.12))
+  (fp_line (start -2.2 2.2) (end -1.65 2.2) (layer F.SilkS) (width 0.12))
+  (fp_line (start -2.2 -2.2) (end -1.65 -2.2) (layer F.SilkS) (width 0.12))
+  (pad 21 thru_hole circle (at 0 0) (size 0.8 0.8) (drill 0.3) (layers *.Cu))
+  (pad 21 thru_hole circle (at -0.9 0) (size 0.8 0.8) (drill 0.3) (layers *.Cu))
+  (pad 21 thru_hole circle (at 0.9 0) (size 0.8 0.8) (drill 0.3) (layers *.Cu))
+  (pad 21 thru_hole circle (at 0.9 -0.9) (size 0.8 0.8) (drill 0.3) (layers *.Cu))
+  (pad 21 thru_hole circle (at -0.9 -0.9) (size 0.8 0.8) (drill 0.3) (layers *.Cu))
+  (pad 21 thru_hole circle (at 0 -0.9) (size 0.8 0.8) (drill 0.3) (layers *.Cu))
+  (pad 21 thru_hole circle (at 0.9 0.9) (size 0.8 0.8) (drill 0.3) (layers *.Cu))
+  (pad 21 thru_hole circle (at -0.9 0.9) (size 0.8 0.8) (drill 0.3) (layers *.Cu))
+  (pad 21 thru_hole circle (at 0 0.9) (size 0.8 0.8) (drill 0.3) (layers *.Cu))
+  (pad 21 smd rect (at 0 0) (size 2.7 2.7) (layers F.Cu F.Mask))
+  (pad 20 smd custom (at -1 -1.69 180) (size 0.28 0.28) (layers F.Cu F.Paste F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.14 0) (xy 0.14 0) (xy 0.14 0.71) (xy -0.14 0.71)) (width 0))
+    ))
+  (pad 19 smd custom (at -0.5 -1.69 180) (size 0.28 0.28) (layers F.Cu F.Paste F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.14 0) (xy 0.14 0) (xy 0.14 0.71) (xy -0.14 0.71)) (width 0))
+    ))
+  (pad 18 smd custom (at 0 -1.69 180) (size 0.28 0.28) (layers F.Cu F.Paste F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.14 0) (xy 0.14 0) (xy 0.14 0.71) (xy -0.14 0.71)) (width 0))
+    ))
+  (pad 17 smd custom (at 0.5 -1.69 180) (size 0.28 0.28) (layers F.Cu F.Paste F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.14 0) (xy 0.14 0) (xy 0.14 0.71) (xy -0.14 0.71)) (width 0))
+    ))
+  (pad 16 smd custom (at 1 -1.69 180) (size 0.28 0.28) (layers F.Cu F.Paste F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.14 0) (xy 0.14 0) (xy 0.14 0.71) (xy -0.14 0.71)) (width 0))
+    ))
+  (pad 15 smd custom (at 1.69 -1 90) (size 0.28 0.28) (layers F.Cu F.Paste F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.14 0) (xy 0.14 0) (xy 0.14 0.71) (xy -0.14 0.71)) (width 0))
+    ))
+  (pad 14 smd custom (at 1.69 -0.5 90) (size 0.28 0.28) (layers F.Cu F.Paste F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.14 0) (xy 0.14 0) (xy 0.14 0.71) (xy -0.14 0.71)) (width 0))
+    ))
+  (pad 13 smd custom (at 1.69 0 90) (size 0.28 0.28) (layers F.Cu F.Paste F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.14 0) (xy 0.14 0) (xy 0.14 0.71) (xy -0.14 0.71)) (width 0))
+    ))
+  (pad 12 smd custom (at 1.69 0.5 90) (size 0.28 0.28) (layers F.Cu F.Paste F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.14 0) (xy 0.14 0) (xy 0.14 0.71) (xy -0.14 0.71)) (width 0))
+    ))
+  (pad 11 smd custom (at 1.69 1 90) (size 0.28 0.28) (layers F.Cu F.Paste F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.14 0) (xy 0.14 0) (xy 0.14 0.71) (xy -0.14 0.71)) (width 0))
+    ))
+  (pad 10 smd custom (at 1 1.69) (size 0.28 0.28) (layers F.Cu F.Paste F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.14 0) (xy 0.14 0) (xy 0.14 0.71) (xy -0.14 0.71)) (width 0))
+    ))
+  (pad 9 smd custom (at 0.5 1.69) (size 0.28 0.28) (layers F.Cu F.Paste F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.14 0) (xy 0.14 0) (xy 0.14 0.71) (xy -0.14 0.71)) (width 0))
+    ))
+  (pad 8 smd custom (at 0 1.69) (size 0.28 0.28) (layers F.Cu F.Paste F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.14 0) (xy 0.14 0) (xy 0.14 0.71) (xy -0.14 0.71)) (width 0))
+    ))
+  (pad 7 smd custom (at -0.5 1.69) (size 0.28 0.28) (layers F.Cu F.Paste F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.14 0) (xy 0.14 0) (xy 0.14 0.71) (xy -0.14 0.71)) (width 0))
+    ))
+  (pad 6 smd custom (at -1 1.69) (size 0.28 0.28) (layers F.Cu F.Paste F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.14 0) (xy 0.14 0) (xy 0.14 0.71) (xy -0.14 0.71)) (width 0))
+    ))
+  (pad 5 smd custom (at -1.69 1 270) (size 0.28 0.28) (layers F.Cu F.Paste F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.14 0) (xy 0.14 0) (xy 0.14 0.71) (xy -0.14 0.71)) (width 0))
+    ))
+  (pad 4 smd custom (at -1.69 0.5 270) (size 0.28 0.28) (layers F.Cu F.Paste F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.14 0) (xy 0.14 0) (xy 0.14 0.71) (xy -0.14 0.71)) (width 0))
+    ))
+  (pad 3 smd custom (at -1.69 0 270) (size 0.28 0.28) (layers F.Cu F.Paste F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.14 0) (xy 0.14 0) (xy 0.14 0.71) (xy -0.14 0.71)) (width 0))
+    ))
+  (pad 2 smd custom (at -1.69 -0.5 270) (size 0.28 0.28) (layers F.Cu F.Paste F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.14 0) (xy 0.14 0) (xy 0.14 0.71) (xy -0.14 0.71)) (width 0))
+    ))
+  (pad 1 smd custom (at -1.69 -1 270) (size 0.28 0.28) (layers F.Cu F.Paste F.Mask)
+    (zone_connect 0)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -0.14 0) (xy 0.14 0) (xy 0.14 0.71) (xy -0.14 0.71)) (width 0))
+    ))
+  (pad "" smd rect (at -0.7 -0.7) (size 1.1 1.1) (layers F.Paste))
+  (pad "" smd rect (at 0.7 -0.7) (size 1.1 1.1) (layers F.Paste))
+  (pad "" smd rect (at 0.7 0.7) (size 1.1 1.1) (layers F.Paste))
+  (pad "" smd rect (at -0.7 0.7) (size 1.1 1.1) (layers F.Paste))
+  (model ${KISYS3DMOD}/Package_DFN_QFN.3dshapes/QFN-20-1EP_4x4mm_P0.5mm_EP2.5x2.5mm.wrl
+    (at (xyz 0 0 0))
+    (scale (xyz 1 1 1))
+    (rotate (xyz 0 0 0))
+  )
+)


### PR DESCRIPTION
Copied from `WQFN-24-1EP_4x4mm_P0.5mm_EP2.7x2.7mm_ThermalVias.kicad_mod`.

This is a footprint for TPA6130A2RTJ (https://github.com/KiCad/kicad-symbols/pull/1621).

**Datasheet:** http://www.ti.com/lit/ds/symlink/tpa6130a2.pdf (page 38).

![Screenshot from 2019-03-09 11-49-27](https://user-images.githubusercontent.com/4582325/54070548-7729cd80-4261-11e9-8f7a-e93f92ee2cb5.png)

---

All contributions to the kicad library must follow the [KiCad library convention](http://kicad-pcb.org/libraries/klc/)

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [x] Provide a URL to a datasheet for the footprint(s) you are contributing
- [x] An example screenshot image is very helpful 
- [ ] If there are matching symbol or 3D model pull requests, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
- [ ] Give a reason behind any intentional library convention rule violation.
