### PR TITLE
Fix #1497 mounting hole positions in Keystone 2468

### DIFF
--- a/Battery.pretty/BatteryHolder_Keystone_2468_2xAAA.kicad_mod
+++ b/Battery.pretty/BatteryHolder_Keystone_2468_2xAAA.kicad_mod
@@ -86,8 +86,8 @@
   )
   (pad 1 thru_hole rect (at 0 0) (size 2 2) (drill 1.02) (layers *.Cu *.Mask))
   (pad 2 thru_hole circle (at 0 12.7) (size 2 2) (drill 1.02) (layers *.Cu *.Mask))
-  (pad "" np_thru_hole circle (at 8.636 8.6995) (size 3.5 3.5) (drill 3.5) (layers *.Cu *.Mask))
-  (pad "" np_thru_hole circle (at 38.608 3.9624) (size 3.5 3.5) (drill 3.5) (layers *.Cu *.Mask))
+  (pad "" np_thru_hole circle (at 8.636 3.9624) (size 3.5 3.5) (drill 3.5) (layers *.Cu *.Mask))
+  (pad "" np_thru_hole circle (at 38.608 8.6995) (size 3.5 3.5) (drill 3.5) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Battery.3dshapes/BatteryHolder_Keystone_2468_2xAAA.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))


### PR DESCRIPTION
Fix #1497 mounting hole positions in Keystone 2468

The issue has a photo of the part in question, and a PCB made with the original footprint.

http://www.keyelco.com/product-pdf.cfm?p=1033

---

All contributions to the kicad library must follow the [KiCad library convention](http://kicad-pcb.org/libraries/klc/)

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [x] Provide a URL to a datasheet for the footprint(s) you are contributing
- [ ] An example screenshot image is very helpful 
- [ ] If there are matching symbol or 3D model pull requests, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
- [ ] Give a reason behind any intentional library convention rule violation.
