### PR TITLE
Added datasheet link

### DIFF
--- a/Crystal.pretty/Crystal_AT310_D3.0mm_L10.0mm_Horizontal.kicad_mod
+++ b/Crystal.pretty/Crystal_AT310_D3.0mm_L10.0mm_Horizontal.kicad_mod
@@ -1,5 +1,5 @@
-(module Crystal_AT310_D3.0mm_L10.0mm_Horizontal (layer F.Cu) (tedit 5A0FD1B2)
-  (descr "Crystal THT AT310 10.0mm-10.5mm length 3.0mm diameter")
+(module Crystal_AT310_D3.0mm_L10.0mm_Horizontal (layer F.Cu) (tedit 5D20AD32)
+  (descr "Crystal THT AT310 10.0mm-10.5mm length 3.0mm diameter http://www.cinetech.com.tw/upload/2011/04/20110401165201.pdf")
   (tags ['AT310'])
   (fp_text reference REF** (at -1.75 3 90) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))

--- a/Crystal.pretty/Crystal_AT310_D3.0mm_L10.0mm_Horizontal_1EP_style1.kicad_mod
+++ b/Crystal.pretty/Crystal_AT310_D3.0mm_L10.0mm_Horizontal_1EP_style1.kicad_mod
@@ -1,5 +1,5 @@
-(module Crystal_AT310_D3.0mm_L10.0mm_Horizontal_1EP_style1 (layer F.Cu) (tedit 5A0FD1B2)
-  (descr "Crystal THT AT310 10.0mm-10.5mm length 3.0mm diameter")
+(module Crystal_AT310_D3.0mm_L10.0mm_Horizontal_1EP_style1 (layer F.Cu) (tedit 5D20AD46)
+  (descr "Crystal THT AT310 10.0mm-10.5mm length 3.0mm diameter http://www.cinetech.com.tw/upload/2011/04/20110401165201.pdf")
   (tags ['AT310'])
   (fp_text reference REF** (at -1.85 3 90) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))

--- a/Crystal.pretty/Crystal_AT310_D3.0mm_L10.0mm_Horizontal_1EP_style2.kicad_mod
+++ b/Crystal.pretty/Crystal_AT310_D3.0mm_L10.0mm_Horizontal_1EP_style2.kicad_mod
@@ -1,5 +1,5 @@
-(module Crystal_AT310_D3.0mm_L10.0mm_Horizontal_1EP_style2 (layer F.Cu) (tedit 5A0FD1B2)
-  (descr "Crystal THT AT310 10.0mm-10.5mm length 3.0mm diameter")
+(module Crystal_AT310_D3.0mm_L10.0mm_Horizontal_1EP_style2 (layer F.Cu) (tedit 5D20AD5C)
+  (descr "Crystal THT AT310 10.0mm-10.5mm length 3.0mm diameter http://www.cinetech.com.tw/upload/2011/04/20110401165201.pdf")
   (tags ['AT310'])
   (fp_text reference REF** (at -1.85 3 90) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))

--- a/Crystal.pretty/Crystal_AT310_D3.0mm_L10.0mm_Vertical.kicad_mod
+++ b/Crystal.pretty/Crystal_AT310_D3.0mm_L10.0mm_Vertical.kicad_mod
@@ -1,5 +1,5 @@
-(module Crystal_AT310_D3.0mm_L10.0mm_Vertical (layer F.Cu) (tedit 5A0FD1B2)
-  (descr "Crystal THT AT310 10.0mm-10.5mm length 3.0mm diameter")
+(module Crystal_AT310_D3.0mm_L10.0mm_Vertical (layer F.Cu) (tedit 5D20AD69)
+  (descr "Crystal THT AT310 10.0mm-10.5mm length 3.0mm diameter http://www.cinetech.com.tw/upload/2011/04/20110401165201.pdf")
   (tags ['AT310'])
   (fp_text reference REF** (at 1.27 -2.7) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))


### PR DESCRIPTION
3D script based model of the AT310 crystal

This push adds the missing data sheet link for the AT310 crystal serie

3D model push
https://github.com/KiCad/kicad-packages3D/pull/586

3D model script push
https://github.com/easyw/kicad-3d-models-in-freecad/pull/302

Removal of hand made models
https://github.com/KiCad/kicad-packages3D-source/pull/233

Update of the data sheet link for the foot print
https://github.com/KiCad/kicad-footprints/pull/1675


Crystal_AT310
http://www.cinetech.com.tw/upload/2011/04/20110401165201.pdf


---

All contributions to the kicad library must follow the [KiCad library convention](http://kicad-pcb.org/libraries/klc/)

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the footprint(s) you are contributing
- [ ] An example screenshot image is very helpful 
- [ ] If there are matching symbol or 3D model pull requests, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
- [ ] Give a reason behind any intentional library convention rule violation.
