### PR TITLE
Fix SW_TH_Tactile_Omron_B3F-10xx pin numbering

### DIFF
--- a/Button_Switch_THT.pretty/SW_TH_Tactile_Omron_B3F-10xx.kicad_mod
+++ b/Button_Switch_THT.pretty/SW_TH_Tactile_Omron_B3F-10xx.kicad_mod
@@ -1,4 +1,4 @@
-(module SW_TH_Tactile_Omron_B3F-10xx (layer F.Cu) (tedit 5D7DF5C1)
+(module SW_TH_Tactile_Omron_B3F-10xx (layer F.Cu) (tedit 5D84F0EF)
   (descr SW_TH_Tactile_Omron_B3F-10xx_https://www.omron.com/ecb/products/pdf/en-b3f.pdf)
   (tags "Omron B3F-10xx")
   (fp_text reference REF** (at 3.25 -2.05) (layer F.SilkS)
@@ -23,9 +23,9 @@
   (fp_line (start 6.37 0.91) (end 6.37 3.59) (layer F.SilkS) (width 0.12))
   (fp_line (start 0.25 5.25) (end 6.25 5.25) (layer F.Fab) (width 0.1))
   (fp_line (start -1.1 -1.1) (end 7.6 -1.1) (layer F.CrtYd) (width 0.05))
-  (pad 2 thru_hole circle (at 6.5 4.5) (size 1.7 1.7) (drill 1) (layers *.Cu *.Mask))
-  (pad 2 thru_hole circle (at 0 4.5) (size 1.7 1.7) (drill 1) (layers *.Cu *.Mask))
-  (pad 1 thru_hole circle (at 6.5 0) (size 1.7 1.7) (drill 1) (layers *.Cu *.Mask))
+  (pad 4 thru_hole circle (at 6.5 4.5) (size 1.7 1.7) (drill 1) (layers *.Cu *.Mask))
+  (pad 3 thru_hole circle (at 0 4.5) (size 1.7 1.7) (drill 1) (layers *.Cu *.Mask))
+  (pad 2 thru_hole circle (at 6.5 0) (size 1.7 1.7) (drill 1) (layers *.Cu *.Mask))
   (pad 1 thru_hole circle (at 0 0) (size 1.7 1.7) (drill 1) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Button_Switch_THT.3dshapes/SW_TH_Tactile_Omron_B3F-10xx.wrl
     (at (xyz 0 0 0))


### PR DESCRIPTION
Restore pin numbers from pre #1856 
Supersedes #1861 

![SW_TH_Tactile_Omron_B3F-10xx](https://user-images.githubusercontent.com/40901018/65339902-5574b000-dbcd-11e9-84f5-325b79bcf56d.png)

---

All contributions to the kicad library must follow the [KiCad library convention](http://kicad-pcb.org/libraries/klc/)

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the footprint(s) you are contributing
- [ ] An example screenshot image is very helpful 
- [ ] If there are matching symbol or 3D model pull requests, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
- [ ] Give a reason behind any intentional library convention rule violation.
