### PR TITLE
Lightpipe_LPF-C012303S is not virtual

### DIFF
--- a/OptoDevice.pretty/Lightpipe_LPF-C012303S.kicad_mod
+++ b/OptoDevice.pretty/Lightpipe_LPF-C012303S.kicad_mod
@@ -1,7 +1,6 @@
-(module Lightpipe_LPF-C012303S (layer F.Cu) (tedit 5D399D83)
+(module Lightpipe_LPF-C012303S (layer F.Cu) (tedit 5E53DE3A)
   (descr https://www.lumex.com/spec/LPF-C012303S.pdf)
   (tags "lightpipe dual tower right angle 3mm")
-  (attr virtual)
   (fp_text reference REF** (at -0.25 -5.75 270) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))
   )


### PR DESCRIPTION
The device will be placed onto the board. Most likely manually, but it will be
assembled and thus should not be virtual (KLC F8.1)


No screenshot or other info, this is pretty straight-forward. 
It is not a breaking change.


edit: I did a rebase onto current master and force-push since travis did check some weird ranged.