### PR TITLE
Replacing LFPAK56 tab with two rectangles, instead of the custom shap…

### DIFF
--- a/Package_TO_SOT_SMD.pretty/LFPAK56.kicad_mod
+++ b/Package_TO_SOT_SMD.pretty/LFPAK56.kicad_mod
@@ -1,4 +1,4 @@
-(module LFPAK56 (layer F.Cu) (tedit 5BA2E0B1)
+(module LFPAK56 (layer F.Cu) (tedit 5E55BAF5)
   (descr "LFPAK56 https://assets.nexperia.com/documents/outline-drawing/SOT669.pdf")
   (tags "LFPAK56 SOT-669 Power-SO8")
   (solder_mask_margin 0.075)
@@ -63,13 +63,10 @@
     (solder_mask_margin 0.07) (solder_paste_margin -0.05))
   (pad "" smd rect (at 2.885 0.6 270) (size 0.6 0.9) (layers F.Paste))
   (pad "" smd rect (at 0.185 0) (size 0.6 0.9) (layers F.Paste))
-  (pad 5 smd custom (at 0.435 0) (size 3.3 4.2) (layers F.Cu F.Mask)
-    (solder_mask_margin 0.07) (zone_connect 2)
-    (options (clearance outline) (anchor rect))
-    (primitives
-      (gr_poly (pts
-         (xy 1.425 -2.35) (xy 2.975 -2.35) (xy 2.975 2.35) (xy 1.425 2.35)) (width 0))
-    ))
+  (pad 5 smd rect (at 0.435 0) (size 3.3 4.2) (layers F.Cu F.Mask)
+    (solder_mask_margin 0.07))
+  (pad 5 smd rect (at 2.635 0) (size 1.55 4.7) (layers F.Cu F.Mask)
+    (solder_mask_margin 0.07))
   (model ${KISYS3DMOD}/Package_TO_SOT_SMD.3dshapes/LFPAK56.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))


### PR DESCRIPTION
…e as thermal reliefs do not work with custom shapes.

Small change to the LFPAK56 footprint, it was previously made up of a custom shape for the tab. I changed it to be two rectangles as thermal reliefs don't work with custom shapes.

Footprint datasheet: https://assets.nexperia.com/documents/outline-drawing/SOT669.pdf
---

All contributions to the kicad library must follow the [KiCad library convention](http://kicad-pcb.org/libraries/klc/)

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the footprint(s) you are contributing
- [ ] An example screenshot image is very helpful 
- [ ] If there are matching symbol or 3D model pull requests, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
- [ ] Give a reason behind any intentional library convention rule violation.

---

Be patient, we maintainers are volunteers with limited time and need to check your contribution against the datasheet. You can speed up the process by providing all the necessary information (see above). And you can speed up the process even more by providing a dimensioned drawing of your contribution. A tutorial on how to do that is found here: https://forum.kicad.info/t/how-to-check-footprint-correctness/9279 (This is optional!)

