### PR TITLE
update datasheet URL

### DIFF
--- a/Connector_RJ.pretty/RJ45_OST_PJ012-8P8CX_Vertical.kicad_mod
+++ b/Connector_RJ.pretty/RJ45_OST_PJ012-8P8CX_Vertical.kicad_mod
@@ -1,5 +1,5 @@
 (module RJ45_OST_PJ012-8P8CX_Vertical (layer F.Cu) (tedit 5C214F77)
-  (descr "RJ45 vertical connector http://www.on-shore.com/wp-content/uploads/2015/09/PJ012-8P8CX.pdf")
+  (descr "RJ45 vertical connector https://www.on-shore.com/wp-content/uploads/PJ012-8P8CX.pdf")
   (tags "RJ45 PJ012")
   (fp_text reference REF** (at 4.45 14) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))


### PR DESCRIPTION
Updating the URL for ON-SHORE PJ012-8P8C1 datasheet. 

The original URL returned a 404. The location without `/2015/09` allows access to the datasheet.

---

All contributions to the kicad library must follow the [KiCad library convention](http://kicad-pcb.org/libraries/klc/)

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the footprint(s) you are contributing
- [ ] An example screenshot image is very helpful 
- [ ] If there are matching symbol or 3D model pull requests, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
- [ ] Give a reason behind any intentional library convention rule violation.

---

Be patient, we maintainers are volunteers with limited time and need to check your contribution against the datasheet. You can speed up the process by providing all the necessary information (see above). And you can speed up the process even more by providing a dimensioned drawing of your contribution. A tutorial on how to do that is found here: https://forum.kicad.info/t/how-to-check-footprint-correctness/9279 (This is optional!)

