### PR TITLE
ublox_NEO: Fix pad 23 type so SMD pad shows up in paste-layer

### DIFF
--- a/RF_GPS.pretty/ublox_NEO.kicad_mod
+++ b/RF_GPS.pretty/ublox_NEO.kicad_mod
@@ -50,7 +50,7 @@
   (pad 20 smd rect (at 6 -2.6) (size 1.8 0.8) (layers F.Cu F.Paste F.Mask))
   (pad 21 smd rect (at 6 -3.7) (size 1.8 0.8) (layers F.Cu F.Paste F.Mask))
   (pad 22 smd rect (at 6 -4.8) (size 1.8 0.8) (layers F.Cu F.Paste F.Mask))
-  (pad 23 connect rect (at 6 -5.9) (size 1.8 0.8) (layers F.Cu F.Mask))
+  (pad 23 smd rect (at 6 -5.9) (size 1.8 0.8) (layers F.Cu F.Paste F.Mask))
   (pad 24 smd rect (at 6 -7) (size 1.8 0.8) (layers F.Cu F.Paste F.Mask))
   (model ${KISYS3DMOD}/RF_GPS.3dshapes/ublox_NEO.wrl
     (at (xyz 0 0 0))


### PR DESCRIPTION
ublox_NEO: Fix pad 23 type so SMD pad shows up in paste-layer

My PCB manufacturer called and informed me that pad 23 was missing in the paste layer / stencil.
I investigated and found that pad 23 type was set to "connect" instead of "smd".
