### PR TITLE
TRANSFORMER: Fix Wurth spelling

### DIFF
--- a/Transformer_THT.pretty/Transformer_Wurth_750343373.kicad_mod
+++ b/Transformer_THT.pretty/Transformer_Wurth_750343373.kicad_mod
@@ -1,10 +1,10 @@
-(module Transformer_Wuerth_750343373 (layer F.Cu) (tedit 5CA646E6)
+(module Transformer_Wurth_750343373 (layer F.Cu) (tedit 5EA9A8D9)
   (descr "Transformer, horizontal core with bobbin, 10 pin, 3.81mm pitch, 15.24mm row spacing, 22x23x17.53mm (https://katalog.we-online.com/ctm/datasheet/750343373.pdf)")
   (tags "transformer flyback")
   (fp_text reference REF** (at 0 -5.08) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (fp_text value Transformer_Wuerth_750343373 (at 7.62 8.89) (layer F.Fab)
+  (fp_text value Transformer_Wurth_750343373 (at 7.62 8.89) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
   (fp_line (start -3.38 -3.88) (end 18.62 -3.88) (layer F.Fab) (width 0.1))
@@ -36,7 +36,7 @@
   (pad 8 thru_hole circle (at 15.24 7.62) (size 2.17 2.17) (drill 1.17) (layers *.Cu *.Mask))
   (pad 9 thru_hole circle (at 15.24 3.81) (size 2.17 2.17) (drill 1.17) (layers *.Cu *.Mask))
   (pad 10 thru_hole circle (at 15.24 0) (size 2.17 2.17) (drill 1.17) (layers *.Cu *.Mask))
-  (model ${KISYS3DMOD}/Transformer_THT.3dshapes/Transformer_Wuerth_750343373.wrl
+  (model ${KISYS3DMOD}/Transformer_THT.3dshapes/Transformer_Wurth_750343373.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))


### PR DESCRIPTION
Everything is in the title.
No modifications of the footprint itself, just fix the name of the manufacturer.

---

All contributions to the kicad library must follow the [KiCad library convention](http://kicad-pcb.org/libraries/klc/)

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the footprint(s) you are contributing
- [ ] An example screenshot image is very helpful 
- [ ] If there are matching symbol or 3D model pull requests, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
- [ ] Give a reason behind any intentional library convention rule violation.

---

Be patient, we maintainers are volunteers with limited time and need to check your contribution against the datasheet. You can speed up the process by providing all the necessary information (see above). And you can speed up the process even more by providing a dimensioned drawing of your contribution. A tutorial on how to do that is found here: https://forum.kicad.info/t/how-to-check-footprint-correctness/9279 (This is optional!)

