### PR TITLE
DRC0010J thermal pad added

### DIFF
--- a/Package_SON.pretty/Texas_DRC0010J_ThermalVias.kicad_mod
+++ b/Package_SON.pretty/Texas_DRC0010J_ThermalVias.kicad_mod
@@ -1,4 +1,4 @@
-(module Texas_DRC0010J_ThermalVias (layer F.Cu) (tedit 5C20F0C0)
+(module Texas_DRC0010J_ThermalVias (layer F.Cu) (tedit 5EF0E9A8)
   (descr "Texas DRC0010J, VSON10 3x3mm Body, 0.5mm Pitch,  http://www.ti.com/lit/ds/symlink/tps63000.pdf")
   (tags "Texas VSON10 3x3mm")
   (attr smd)
@@ -62,6 +62,7 @@
   (pad 11 thru_hole circle (at -0.575 0) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
   (pad 11 thru_hole circle (at 0.575 0) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
   (pad 11 thru_hole circle (at 0 -0.95) (size 0.5 0.5) (drill 0.2) (layers *.Cu))
+  (pad 11 smd rect (at 0 0) (size 2.15 2.9) (layers B.Cu))
   (model ${KISYS3DMOD}/Package_SON.3dshapes/Texas_DRC0010J.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))


### PR DESCRIPTION
Adds a thermal pad to DRC0010J_ThermalVias on B.cu as mentioned in issue #1400
It has a margin of 0.5mm to the vias according to [KLC F4.4](https://kicad-pcb.org/libraries/klc/F4.4/), as there is no recommondation in the [datasheet](https://www.ti.com/lit/ds/symlink/tps765.pdf?ts=1592847751550)

![image](https://user-images.githubusercontent.com/57522931/85318698-ba449a00-b4c0-11ea-8684-94da829bb76b.png)

---

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [x] Provide a URL to a datasheet for the footprint(s) you are contributing
- [x] An example screenshot image is very helpful 
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
- [ ] Give a reason behind any intentional library convention rule violation.

---

Be patient, we maintainers are volunteers with limited time and need to check your contribution against the datasheet. You can speed up the process by providing all the necessary information (see above). And you can speed up the process even more by providing a dimensioned drawing of your contribution. A tutorial on how to do that is found here: https://forum.kicad.info/t/how-to-check-footprint-correctness/9279 (This is optional!)
