### PR TITLE
Update SOIC-8_5.23x5.23mm_P1.27mm.kicad_mod

### DIFF
--- a/Package_SO.pretty/SOIC-8_5.23x5.23mm_P1.27mm.kicad_mod
+++ b/Package_SO.pretty/SOIC-8_5.23x5.23mm_P1.27mm.kicad_mod
@@ -37,7 +37,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Package_SO.3dshapes/SOIC-8_5.23x5.23mm_P1.27mm.wrl
+  (model ${KISYS3DMOD}/Package_SO.3dshapes/SOIC-8_5.275x5.275mm_P1.27mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))


### PR DESCRIPTION
Fixed default 3D package (version 5.1.6 uses non existant 3d model)

*Replace this line with your commit message! Please provide a description of your pull request*

---

All contributions to the kicad library must follow the [KiCad library convention](http://kicad-pcb.org/libraries/klc/)

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [x] Provide a URL to a datasheet for the footprint(s) you are contributing
- [x] An example screenshot image is very helpful 
- [x] If there are matching symbol or 3D model pull requests, provide link(s) as appropriate
- [x] Check the output of the Travis automated check scripts - fix any errors as required
- [x] Give a reason behind any intentional library convention rule violation.

---

Be patient, we maintainers are volunteers with limited time and need to check your contribution against the datasheet. You can speed up the process by providing all the necessary information (see above). And you can speed up the process even more by providing a dimensioned drawing of your contribution. A tutorial on how to do that is found here: https://forum.kicad.info/t/how-to-check-footprint-correctness/9279 (This is optional!)

