### PR TITLE
Fix HVSON-8-1EP_3x3mm_P0.65mm_EP1.6x2.4mm datasheet URL

### DIFF
--- a/Package_SON.pretty/HVSON-8-1EP_3x3mm_P0.65mm_EP1.6x2.4mm.kicad_mod
+++ b/Package_SON.pretty/HVSON-8-1EP_3x3mm_P0.65mm_EP1.6x2.4mm.kicad_mod
@@ -1,5 +1,5 @@
-(module HVSON-8-1EP_3x3mm_P0.65mm_EP1.6x2.4mm (layer F.Cu) (tedit 5F23270E)
-  (descr "HVSON, 8 Pin (https://www.nxp.com/docs/en/data-sheet/TJA1051.pdf (page 16)), generated with kicad-footprint-generator ipc_noLead_generator.py")
+(module HVSON-8-1EP_3x3mm_P0.65mm_EP1.6x2.4mm (layer F.Cu) (tedit 5F2C5F6B)
+  (descr "HVSON, 8 Pin (https://www.nxp.com/docs/en/data-sheet/TJA1051.pdf#page=16), generated with kicad-footprint-generator ipc_noLead_generator.py")
   (tags "HVSON NoLead")
   (attr smd)
   (fp_text reference REF** (at 0 -2.45) (layer F.SilkS)


### PR DESCRIPTION
Fix one line in already merged footprint.

---

All contributions to the kicad library must follow the [KiCad library convention](http://kicad-pcb.org/libraries/klc/)

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the footprint(s) you are contributing
- [ ] An example screenshot image is very helpful 
- [ ] If there are matching symbol or 3D model pull requests, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
- [ ] Give a reason behind any intentional library convention rule violation.

---

Be patient, we maintainers are volunteers with limited time and need to check your contribution against the datasheet. You can speed up the process by providing all the necessary information (see above). And you can speed up the process even more by providing a dimensioned drawing of your contribution. A tutorial on how to do that is found here: https://forum.kicad.info/t/how-to-check-footprint-correctness/9279 (This is optional!)

