### PR TITLE
More accurate description for D_MiniMELF

### DIFF
--- a/Diode_SMD.pretty/D_MiniMELF.kicad_mod
+++ b/Diode_SMD.pretty/D_MiniMELF.kicad_mod
@@ -1,6 +1,6 @@
 (module D_MiniMELF (layer F.Cu) (tedit 5905D8F5)
-  (descr "Diode Mini-MELF")
-  (tags "Diode Mini-MELF")
+  (descr "Diode Mini-MELF (SOD-80)")
+  (tags "Diode Mini-MELF (SOD-80)")
   (attr smd)
   (fp_text reference REF** (at 0 -2) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))

--- a/Diode_SMD.pretty/D_MiniMELF_Handsoldering.kicad_mod
+++ b/Diode_SMD.pretty/D_MiniMELF_Handsoldering.kicad_mod
@@ -1,6 +1,6 @@
 (module D_MiniMELF_Handsoldering (layer F.Cu) (tedit 5905D919)
-  (descr "Diode Mini-MELF Handsoldering")
-  (tags "Diode Mini-MELF Handsoldering")
+  (descr "Diode Mini-MELF (SOD-80) Handsoldering")
+  (tags "Diode Mini-MELF (SOD-80) Handsoldering")
   (attr smd)
   (fp_text reference REF** (at 0 -1.75) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))


### PR DESCRIPTION
MiniMELF and SOD-80 footprints are identical, so I added word "SOD-80" in existing D_MiniMELF.kicad_mod's description and Tag. This will improve searching.
Datasheet: https://www.vishay.com/docs/85557/ll4148.pdf#page=3

---

All contributions to the kicad library must follow the [KiCad library convention](http://kicad-pcb.org/libraries/klc/)

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the footprint(s) you are contributing
- [ ] An example screenshot image is very helpful 
- [ ] If there are matching symbol or 3D model pull requests, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
- [ ] Give a reason behind any intentional library convention rule violation.

---

Be patient, we maintainers are volunteers with limited time and need to check your contribution against the datasheet. You can speed up the process by providing all the necessary information (see above). And you can speed up the process even more by providing a dimensioned drawing of your contribution. A tutorial on how to do that is found here: https://forum.kicad.info/t/how-to-check-footprint-correctness/9279 (This is optional!)

