### PR TITLE
Bugfix: Buzzer_Beeper.pretty/MagneticBuzzer_Kobitone_254-EMB84Q-RO

### DIFF
--- a/Buzzer_Beeper.pretty/MagneticBuzzer_Kobitone_254-EMB84Q-RO.kicad_mod
+++ b/Buzzer_Beeper.pretty/MagneticBuzzer_Kobitone_254-EMB84Q-RO.kicad_mod
@@ -31,7 +31,7 @@
   (pad 3 smd rect (at 3.7 3.7 270) (size 2.195 2.195) (layers F.Cu F.Paste F.Mask))
   (pad 2 smd rect (at -3.7 3.7 270) (size 2.195 2.195) (layers F.Cu F.Paste F.Mask))
   (pad 1 smd rect (at -3.7 -3.7 270) (size 2.195 2.195) (layers F.Cu F.Paste F.Mask))
-  (model ${KISYS3DMOD}/${KISYS3DMOD}/Buzzer_Beeper.3dshapes/MagneticBuzzer_Kobitone_254-EMB84Q-RO.wrl
+  (model ${KISYS3DMOD}/Buzzer_Beeper.3dshapes/MagneticBuzzer_Kobitone_254-EMB84Q-RO.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))


### PR DESCRIPTION
   wrong path for 3D model in file of "MagneticBuzzer_Kobitone_254-EMB84Q-RO"
   ${KISYS3DMOD} was used twice in path name

On branch mountyrox_BugfixMagneticBuzzer
Changes to be committed:
	modified:   Buzzer_Beeper.pretty/MagneticBuzzer_Kobitone_254-EMB84Q-RO.kicad_mod

---

All contributions to the kicad library must follow the [KiCad library convention](http://kicad-pcb.org/libraries/klc/)

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [x ] Provide a URL to a datasheet for the footprint(s) you are contributing **(already included)**
- [ ] An example screenshot image is very helpful 
- [x ] If there are matching symbol or 3D model pull requests, provide link(s) as appropriate  **(already included)**
- [x ] Check the output of the Travis automated check scripts - fix any errors as required
- [ ] Give a reason behind any intentional library convention rule violation.

---

Be patient, we maintainers are volunteers with limited time and need to check your contribution against the datasheet. You can speed up the process by providing all the necessary information (see above). And you can speed up the process even more by providing a dimensioned drawing of your contribution. A tutorial on how to do that is found here: https://forum.kicad.info/t/how-to-check-footprint-correctness/9279 (This is optional!)

