### PR TITLE
Bugfix:  Position of lower mounting hole was wrong

### DIFF
--- a/Battery.pretty/BatteryHolder_Eagle_12BH611-GR.kicad_mod
+++ b/Battery.pretty/BatteryHolder_Eagle_12BH611-GR.kicad_mod
@@ -1,4 +1,4 @@
-(module BatteryHolder_Eagle_12BH611-GR (layer F.Cu) (tedit 5BFC95F9)
+(module BatteryHolder_Eagle_12BH611-GR (layer F.Cu) (tedit 5F4B6D66)
   (descr https://eu.mouser.com/datasheet/2/209/EPD-200766-1274481.pdf)
   (tags "9V Battery Holder")
   (fp_text reference REF** (at -24.13 -24.13) (layer F.SilkS)
@@ -54,7 +54,7 @@
   (pad 1 thru_hole rect (at 0 0) (size 3 3) (drill 2.4) (layers *.Cu *.Mask))
   (pad "" np_thru_hole circle (at -10.9 -17.45) (size 2.6 2.6) (drill 2.6) (layers *.Cu *.Mask))
   (pad "" np_thru_hole circle (at -38.9 -17.45) (size 2.6 2.6) (drill 2.6) (layers *.Cu *.Mask))
-  (pad "" np_thru_hole circle (at -24.9 4.75) (size 2.6 2.6) (drill 2.6) (layers *.Cu *.Mask))
+  (pad "" np_thru_hole circle (at -24.15 4.75) (size 2.6 2.6) (drill 2.6) (layers *.Cu *.Mask))
   (model ${KISYS3DMOD}/Battery.3dshapes/BatteryHolder_Eagle_12BH611-GR.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))


### PR DESCRIPTION
The position of the lower mounting hole had to be shifted by 0.75 mm to the left. The previous position did not correspond to the technical drawing of the device.

 https://eu.mouser.com/datasheet/2/209/EPD-200766-1274481.pdf

 On branch mountyrox_BhEagle
 Changes to be committed:
	modified:   Battery.pretty/BatteryHolder_Eagle_12BH611-GR.kicad_mod

See discussion on issue https://github.com/KiCad/kicad-packages3D-source/pull/290

The corrected footprint is in in line with the new 3d model (bottom view).
![bh_bot](https://user-images.githubusercontent.com/68644672/91739509-4b677980-ebb2-11ea-87a1-0ec222b0df3e.png)

---

- [x ] Provide a URL to a datasheet for the footprint(s) you are contributing
- [x ] An example screenshot image is very helpful 
- [x ] If there are matching symbol or 3D model pull requests, provide link(s) as appropriate **(in process see issue above)**
- [x ] Check the output of the Travis automated check scripts - fix any errors as required
- [ ] Give a reason behind any intentional library convention rule violation.

---

Be patient, we maintainers are volunteers with limited time and need to check your contribution against the datasheet. You can speed up the process by providing all the necessary information (see above). And you can speed up the process even more by providing a dimensioned drawing of your contribution. A tutorial on how to do that is found here: https://forum.kicad.info/t/how-to-check-footprint-correctness/9279 (This is optional!)

