### PR TITLE
fix BGA-132_12x18mm_Layout11x17_P0.5mm

### DIFF
--- a/Package_BGA.pretty/BGA-132_12x18mm_Layout11x17_P1.0mm.kicad_mod
+++ b/Package_BGA.pretty/BGA-132_12x18mm_Layout11x17_P1.0mm.kicad_mod
@@ -1,11 +1,11 @@
-(module BGA-132_12x18mm_Layout11x17_P0.5mm (layer F.Cu) (tedit 5A058D74)
-  (descr "BGA-132 11x17 12x18mm 0.5pitch")
+(module BGA-132_12x18mm_Layout11x17_P1.0mm (layer F.Cu) (tedit 5F50A608)
+  (descr "BGA-132 11x17 12x18mm 1.0pitch")
   (tags BGA-132)
   (attr smd)
   (fp_text reference REF** (at 0 -10.2) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (fp_text value BGA-132_12x18mm_Layout11x17_P0.5mm (at 0 10.2) (layer F.Fab)
+  (fp_text value BGA-132_12x18mm_Layout11x17_P1.0mm (at 0 10.2) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
   (fp_line (start -5 -9.4) (end -6.4 -9.4) (layer F.SilkS) (width 0.15))
@@ -158,7 +158,7 @@
   (pad R11 smd circle (at 5 6) (size 0.5 0.5) (layers F.Cu F.Paste F.Mask))
   (pad T11 smd circle (at 5 7) (size 0.5 0.5) (layers F.Cu F.Paste F.Mask))
   (pad U11 smd circle (at 5 8) (size 0.5 0.5) (layers F.Cu F.Paste F.Mask))
-  (model ${KISYS3DMOD}/Package_BGA.3dshapes/BGA-132_12x18mm_Layout11x17_P0.5mm.wrl
+  (model ${KISYS3DMOD}/Package_BGA.3dshapes/BGA-132_12x18mm_Layout11x17_P1.0mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))


### PR DESCRIPTION
remove BGA-132_12x18mm_Layout11x17_P**0.5**mm and adds BGA-132_12x18mm_Layout11x17_P**1.0**mm.
Actual pitch was correct but in filename and description screwed up.

page 23: http://www.onfi.org/-/media/client/onfi/specs/onfi_4_2-gold.pdf?la=en

---

All contributions to the kicad library must follow the [KiCad library convention](http://kicad-pcb.org/libraries/klc/)

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [x] Provide a URL to a datasheet for the footprint(s) you are contributing
- [ ] An example screenshot image is very helpful 
- [ ] If there are matching symbol or 3D model pull requests, provide link(s) as appropriate
- [x] Check the output of the Travis automated check scripts - fix any errors as required
- [ ] Give a reason behind any intentional library convention rule violation.

---

Be patient, we maintainers are volunteers with limited time and need to check your contribution against the datasheet. You can speed up the process by providing all the necessary information (see above). And you can speed up the process even more by providing a dimensioned drawing of your contribution. A tutorial on how to do that is found here: https://forum.kicad.info/t/how-to-check-footprint-correctness/9279 (This is optional!)

